### PR TITLE
Add functionality to extract root sequences after rerooting

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,6 +14,9 @@ rule all:
         # Unaligned coding sequences for HA segments by subtype
         expand("results/HA/{subtype}/curated_unaligned_coding_seqs.fasta.xz",
                subtype=config["ha_subtypes"]),
+        # Root sequences for HA segments by subtype
+        expand("results/HA/{subtype}/curated_root.fasta",
+               subtype=config["ha_subtypes"]),
         # Trees for NA segments by subtype
         expand("results/NA/{subtype}/final_tree.pb.gz",
                subtype=config["na_subtypes"]),
@@ -22,6 +25,9 @@ rule all:
         # Unaligned coding sequences for NA segments by subtype
         expand("results/NA/{subtype}/curated_unaligned_coding_seqs.fasta.xz",
                subtype=config["na_subtypes"]),
+        # Root sequences for NA segments by subtype
+        expand("results/NA/{subtype}/curated_root.fasta",
+               subtype=config["na_subtypes"]),
         # Trees for other segments (all subtypes combined)
         expand("results/{segment}/all/final_tree.pb.gz",
                segment=[s for s in config["segments"] if s not in ["HA", "NA"]]),
@@ -29,6 +35,9 @@ rule all:
                segment=[s for s in config["segments"] if s not in ["HA", "NA"]]),
         # Unaligned coding sequences for other segments (all subtypes combined)
         expand("results/{segment}/all/curated_unaligned_coding_seqs.fasta.xz",
+               segment=[s for s in config["segments"] if s not in ["HA", "NA"]]),
+        # Root sequences for other segments (all subtypes combined)
+        expand("results/{segment}/all/curated_root.fasta",
                segment=[s for s in config["segments"] if s not in ["HA", "NA"]])
 
 # Parse GISAID data files from all input directories at once
@@ -365,6 +374,32 @@ rule reroot_tree:
             shell("""
                 ln -sf $(basename {input}) {output} \
                 && echo "Created symlink for {key} (no rerooting specified)" > {log}
+            """)
+
+# Extract root sequence from MSA or create symlink to reference
+rule create_root_fasta:
+    input:
+        msa="results/{segment}/{subtype}/curated_msa.fasta.xz",
+        ref="results/{segment}/{subtype}/curated_reference.fasta"
+    output:
+        "results/{segment}/{subtype}/curated_root.fasta"
+    log:
+        "logs/{segment}/{subtype}/create_root_fasta.log"
+    run:
+        key = f"{wildcards.segment}_{wildcards.subtype}"
+        if key in config.get("reroot", {}):
+            root_name = config["reroot"][key]
+            shell("""
+                python scripts/extract_sequence_from_msa.py \
+                    --msa {input.msa} \
+                    --sequence-name {root_name} \
+                    --output {output} \
+                    &> {log}
+            """)
+        else:
+            shell("""
+                ln -sf $(basename {input.ref}) {output} \
+                && echo "Created symlink (no rerooting specified)" > {log}
             """)
 
 

--- a/scripts/extract_sequence_from_msa.py
+++ b/scripts/extract_sequence_from_msa.py
@@ -1,0 +1,31 @@
+"""
+Extract a specific sequence from a compressed MSA file by sequence name.
+"""
+import argparse
+import lzma
+from Bio import SeqIO
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--msa", required=True, help="Input MSA file (.fasta.xz)")
+    parser.add_argument("--sequence-name", required=True, help="Name of sequence to extract")
+    parser.add_argument("--output", required=True, help="Output FASTA file")
+    args = parser.parse_args()
+
+    # Read compressed MSA
+    with lzma.open(args.msa, 'rt') as f:
+        sequences = SeqIO.parse(f, 'fasta')
+
+        # Find the target sequence
+        for record in sequences:
+            if record.id == args.sequence_name:
+                # Write to output
+                with open(args.output, 'w') as out:
+                    SeqIO.write(record, out, 'fasta')
+                print(f"Extracted sequence: {args.sequence_name}")
+                return
+
+    raise ValueError(f"Sequence '{args.sequence_name}' not found in MSA")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements functionality to extract root node sequences from curated MSA files after tree rerooting, as outlined in issue #5.

- Created `scripts/extract_sequence_from_msa.py` to extract sequences by name from compressed FASTA files
- Added `create_root_fasta` Snakemake rule that:
  - Extracts root sequence from MSA when rerooting is specified in config
  - Creates symlink to reference sequence when no rerooting is specified
- Updated `rule all` to include `curated_root.fasta` outputs for all segment-subtype combinations

This provides root sequences in the same format as `curated_reference.fasta`, enabling downstream analyses that need the root sequence and allowing comparison between reference and inferred root.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)