### PR TITLE
Add rerooting configuration for internal segment trees

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -91,6 +91,12 @@ reroot:
   "HA_H3": "EPI_ISL_18852459"
   "HA_H5": "EPI_ISL_5886"
   "HA_H7": "EPI_ISL_10304"
+  "PB2_all": "EPI_ISL_5886"
+  "PB1_all": "EPI_ISL_5886"
+  "PA_all": "EPI_ISL_5886"
+  "NP_all": "EPI_ISL_5886"
+  "MP_all": "EPI_ISL_5886"
+  "NS_all": "EPI_ISL_5886"
 
 # Host-specific subtree extraction
 host_groups_to_extract:


### PR DESCRIPTION
## Summary
Adds rerooting configuration for all 6 internal segment trees (PB2, PB1, PA, NP, MP, NS) using EPI_ISL_5886 as the root node.

## Changes
- Updated `config.yaml` to add rerooting entries for:
  - PB2_all
  - PB1_all
  - PA_all
  - NP_all
  - MP_all
  - NS_all

## Rationale
- **EPI_ISL_5886** (A/turkey/Ontario/7732/1966, H5N9) is present in all 6 internal segment alignments
- Provides consistency across all internal segments
- Already used for HA_H5, maintaining alignment across related segments
- Early (1966) avian sequence provides good outgroup rooting

## Expected Behavior
After rerunning the pipeline for internal segments:
- Trees will be rerooted at EPI_ISL_5886
- `final_tree.pb.gz` files will contain rerooted trees instead of being symlinks to `sampled_tree.pb.gz`
- The `reroot_tree` rule will use `matUtils extract -y` to perform rerooting

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)