### PR TITLE
Refactor reference downloads to use sequential batch processing

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -62,23 +62,40 @@ rule parse_gisaid_data:
             &> {log}
         """
 
-# Download the reference sequence and corresponding GFF, create a Nextclade pathogen.json file,
-# and save these files in the same directory as input to Nextclade
-rule download_reference:
+# Download all reference sequences sequentially with fixed wait time between downloads
+# This prevents NCBI rate limiting and provides predictable runtime
+rule download_all_references:
     output:
-        directory("results/{segment}/{subtype}/reference/"),
-        gff="results/{segment}/{subtype}/reference/reference.gff",
-        fasta="results/{segment}/{subtype}/reference/reference.fasta",
-        json="results/{segment}/{subtype}/reference/pathogen.json"
+        # Explicitly list all expected outputs for Snakemake dependency tracking
+        fastas=expand("results/HA/{subtype}/reference/reference.fasta",
+                     subtype=config["ha_subtypes"]) + \
+              expand("results/NA/{subtype}/reference/reference.fasta",
+                     subtype=config["na_subtypes"]) + \
+              expand("results/{segment}/all/reference/reference.fasta",
+                     segment=[s for s in config["segments"] if s not in ["HA", "NA"]]),
+        gffs=expand("results/HA/{subtype}/reference/reference.gff",
+                   subtype=config["ha_subtypes"]) + \
+             expand("results/NA/{subtype}/reference/reference.gff",
+                    subtype=config["na_subtypes"]) + \
+             expand("results/{segment}/all/reference/reference.gff",
+                    segment=[s for s in config["segments"] if s not in ["HA", "NA"]]),
+        jsons=expand("results/HA/{subtype}/reference/pathogen.json",
+                    subtype=config["ha_subtypes"]) + \
+              expand("results/NA/{subtype}/reference/pathogen.json",
+                     subtype=config["na_subtypes"]) + \
+              expand("results/{segment}/all/reference/pathogen.json",
+                     segment=[s for s in config["segments"] if s not in ["HA", "NA"]])
     params:
-        accession=lambda wildcards: config["references"][f"{wildcards.segment}_{wildcards.subtype}"]
+        config_file="config.yaml",
+        wait_time=30
     log:
-        "logs/{segment}/{subtype}/download_reference.log"
+        "logs/download_all_references.log"
     shell:
         """
         python scripts/download_ref_seq.py \
-            --accession {params.accession} \
-            --output-dir {output[0]} \
+            --config {params.config_file} \
+            --output-base-dir results \
+            --wait-time {params.wait_time} \
             &> {log}
         """
 

--- a/scripts/download_ref_seq.py
+++ b/scripts/download_ref_seq.py
@@ -4,12 +4,13 @@ import json
 import argparse
 import sys
 import time
-import random
+import yaml
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Download reference sequences for flu-usher")
-    parser.add_argument("--accession", required=True, help="Reference sequence accession number")
-    parser.add_argument("--output-dir", required=True, help="Output directory for reference files")
+    parser.add_argument("--config", required=True, help="Path to config.yaml file")
+    parser.add_argument("--output-base-dir", required=True, help="Base output directory (e.g., 'results')")
+    parser.add_argument("--wait-time", type=int, default=30, help="Seconds to wait between downloads (default: 30)")
     return parser.parse_args()
 
 def download_gene_sequence(accession, output_dir):
@@ -18,13 +19,13 @@ def download_gene_sequence(accession, output_dir):
     handle = Entrez.efetch(db="nucleotide", id=accession, rettype="fasta", retmode="text")
     sequence = handle.read()
     handle.close()
-    
+
     # Save to file
     output_fasta = os.path.join(output_dir, "reference.fasta")
     with open(output_fasta, "w") as f:
         f.write(sequence)
-    
-    print(f"Sequence saved to {output_fasta}")
+
+    print(f"  Sequence saved to {output_fasta}")
     return output_fasta
 
 def download_gene_gff(accession, output_dir):
@@ -33,44 +34,22 @@ def download_gene_gff(accession, output_dir):
     handle = Entrez.efetch(db="nucleotide", id=accession, rettype="gb", retmode="text")
     record = SeqIO.read(handle, "genbank")
     handle.close()
-    
+
     # Fetch the GFF
     handle = Entrez.efetch(db="nucleotide", id=accession, rettype="gff3", retmode="text")
     gff_content = handle.read()
     handle.close()
-    
+
     # Save to file
     output_gff = os.path.join(output_dir, "reference.gff")
     with open(output_gff, "w") as f:
         f.write(gff_content)
-    
-    print(f"GFF saved to {output_gff}")
+
+    print(f"  GFF saved to {output_gff}")
     return output_gff
 
-def main():
-    args = parse_args()
-    
-    # Create output directory if it doesn't exist
-    print("Current working directory:", os.getcwd())
-    print("Output directory:", args.output_dir)
-    if os.path.isdir(args.output_dir):
-        print("Output directory already exists:", args.output_dir)
-    if not os.path.isdir(args.output_dir):
-        print("Making output directory:", args.output_dir)
-        os.makedirs(args.output_dir)
-    
-    # Download reference files
-    Entrez.email = 'test_window238476@gmail.com'
-
-    # Wait for a random amount of time before downloading
-    wait_time = random.uniform(0, 500)
-    print(f"Waiting {wait_time:.1f} seconds before downloading to avoid error related to too many requests.")
-    time.sleep(wait_time)
-    fasta_file = download_gene_sequence(args.accession, args.output_dir)
-    time.sleep(20)  # Wait for 20 seconds before downloading GFF
-    gff_file = download_gene_gff(args.accession, args.output_dir)
-    
-    # Create pathogen.json for Nextclade
+def create_pathogen_json(output_dir, fasta_file, gff_file):
+    """Create pathogen.json for Nextclade"""
     pathogen_json = {
         "schemaVersion": "3.0.0",
         "files": {
@@ -82,14 +61,109 @@ def main():
             "minSeedCover": 0.1
         }
     }
-    
+
     # Write pathogen_json to a JSON file
-    json_file_path = os.path.join(args.output_dir, "pathogen.json")
+    json_file_path = os.path.join(output_dir, "pathogen.json")
     with open(json_file_path, 'w') as f:
         json.dump(pathogen_json, f, indent=2)
-    
-    print(f"Pathogen JSON saved to {json_file_path}")
-    print(f"Reference data downloaded successfully to {args.output_dir}")
+
+    print(f"  Pathogen JSON saved to {json_file_path}")
+    return json_file_path
+
+def download_reference_set(segment, subtype, accession, output_base_dir):
+    """Download FASTA, GFF, and create pathogen.json for a segment/subtype combination"""
+    # Create output directory
+    output_dir = os.path.join(output_base_dir, segment, subtype, "reference")
+
+    print(f"\nProcessing {segment}/{subtype} (accession: {accession})")
+
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+        print(f"  Created directory: {output_dir}")
+    else:
+        print(f"  Directory exists: {output_dir}")
+
+    try:
+        # Download FASTA
+        fasta_file = download_gene_sequence(accession, output_dir)
+
+        # Wait 3 seconds before downloading GFF
+        time.sleep(3)
+
+        # Download GFF
+        gff_file = download_gene_gff(accession, output_dir)
+
+        # Create pathogen.json
+        json_file = create_pathogen_json(output_dir, fasta_file, gff_file)
+
+        print(f"  ✓ Successfully downloaded reference files for {segment}/{subtype}")
+        return True
+
+    except Exception as e:
+        print(f"  ✗ Error downloading reference for {segment}/{subtype}: {e}", file=sys.stderr)
+        return False
+
+def main():
+    args = parse_args()
+
+    # Set Entrez email
+    Entrez.email = 'test_window238476@gmail.com'
+
+    # Load config file
+    print(f"Loading configuration from {args.config}")
+    with open(args.config, 'r') as f:
+        config = yaml.safe_load(f)
+
+    # Build list of segment/subtype/accession combinations
+    combinations = []
+
+    # Add HA subtypes
+    for subtype in config["ha_subtypes"]:
+        ref_key = f"HA_{subtype}"
+        if ref_key in config["references"]:
+            combinations.append(("HA", subtype, config["references"][ref_key]))
+
+    # Add NA subtypes
+    for subtype in config["na_subtypes"]:
+        ref_key = f"NA_{subtype}"
+        if ref_key in config["references"]:
+            combinations.append(("NA", subtype, config["references"][ref_key]))
+
+    # Add internal segments (all subtypes combined)
+    for segment in config["segments"]:
+        if segment not in ["HA", "NA"]:
+            ref_key = f"{segment}_all"
+            if ref_key in config["references"]:
+                combinations.append((segment, "all", config["references"][ref_key]))
+
+    print(f"\nFound {len(combinations)} segment/subtype combinations to process")
+    print(f"Wait time between downloads: {args.wait_time} seconds")
+    print(f"Estimated total runtime: ~{len(combinations) * args.wait_time // 60} minutes\n")
+    print("=" * 70)
+
+    # Process each combination sequentially
+    success_count = 0
+    for i, (segment, subtype, accession) in enumerate(combinations, 1):
+        # Wait before downloading (except for first download)
+        if i > 1:
+            print(f"\nWaiting {args.wait_time} seconds before next download...")
+            time.sleep(args.wait_time)
+
+        print(f"\n[{i}/{len(combinations)}]", end=" ")
+
+        # Download reference files
+        success = download_reference_set(segment, subtype, accession, args.output_base_dir)
+
+        if success:
+            success_count += 1
+        else:
+            print(f"\nFailed to download reference for {segment}/{subtype}", file=sys.stderr)
+            sys.exit(1)
+
+    # Final summary
+    print("\n" + "=" * 70)
+    print(f"\nCompleted: {success_count}/{len(combinations)} downloads successful")
+    print(f"All reference data downloaded successfully to {args.output_base_dir}\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
Refactors the reference download system from parallel per-combination downloads with random waits to a single sequential batch process with fixed wait times. This provides predictable runtime and better compliance with NCBI rate limits.

## Changes Made

### 1. Rewrote `scripts/download_ref_seq.py`
**Before:**
- Processed single segment/subtype combination per execution
- Random wait of 0-500 seconds before each download
- Called separately for each of 14 combinations (parallel)

**After:**
- Processes all 14 segment/subtype combinations in single execution
- Fixed 30-second wait between downloads (except first)
- Reads config.yaml to automatically discover all combinations
- Sequential processing with progress tracking [X/14]
- Fail-fast error handling
- Reduced wait between FASTA and GFF from 20s to 3s

### 2. Updated `Snakefile` 
**Before:** `download_reference` rule with wildcards
- Created 14 separate parallel jobs
- Each with own log file

**After:** `download_all_references` aggregate rule
- Single job processes all combinations
- Explicitly lists all 42 output files (14 combinations × 3 files)
- Single comprehensive log: `logs/download_all_references.log`

## Benefits
- **Predictable runtime**: ~7-8 minutes total (vs unpredictable 0-2+ hours)
- **Better NCBI compliance**: Sequential access with fixed waits respects rate limits
- **Simpler logging**: Single log file with progress tracking instead of 14 separate logs
- **Easier debugging**: Clear progress messages and status indicators
- **More reliable**: No parallel download conflicts

## Backwards Compatibility
✅ **Full backwards compatibility maintained:**
- All output files in same locations: `results/{segment}/{subtype}/reference/{reference.fasta, reference.gff, pathogen.json}`
- Downstream rules work without modification
- No changes to config.yaml needed
- PyYAML dependency already available

## Testing
Dry-run verification confirms:
- ✅ Rule syntax correct
- ✅ All 42 output files listed
- ✅ Downstream rules resolve dependencies correctly
- ✅ Script arguments updated properly

**To test the actual download:**
```bash
snakemake --forcerun download_all_references --cores 1
```

Expected runtime: ~7-8 minutes for all 14 downloads

## Documentation
Added comprehensive documentation:
- `IMPLEMENTATION_SUMMARY.md` - Detailed implementation notes
- `VERIFICATION_CHECKLIST.md` - Testing and verification steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)