### PR TITLE
Per-node host inference via PastML

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ flu-usher/
 │   ├── simplified_host_classifier.py               # Classify hosts into groups (used by augment_metadata.py)
 │   ├── augment_metadata.py                         # Add host, geographic, and temporal group columns to metadata
 │   ├── create_samples_file.py                      # Create samples file for subtree extraction (generic column filter)
-│   └── create_temporal_samples_file.py             # Create samples file for temporal subtree extraction
+│   ├── create_temporal_samples_file.py             # Create samples file for temporal subtree extraction
+│   └── prepare_host_annotation.py                  # Build 2-col CSV (isolate_id, host_group) for PastML
 └── notebooks/               # Jupyter notebooks for development and analysis
 ```
 
@@ -140,6 +141,10 @@ flu-usher/
      - `{temporal_group}_samples.txt`: Sample list for each temporal group
      - `{temporal_group}_tree.pb.gz`: Extracted subtree for each temporal group
      - `{temporal_group}_tree.jsonl.gz`: Taxonium visualization for each temporal group
+   - `host_ancestral/`: Per-node host inference (PastML / DOWNPASS)
+     - `combined_ancestral_states.tab`: Tab-separated file of inferred `host_group` for every node (leaves + internals); the `node` column joins to internal node IDs in `final_tree.pb.gz`. Ambiguous internals may appear on multiple rows (one per equally-parsimonious state).
+     - `host_tree.html`: Interactive PastML visualization of the ancestral reconstruction.
+     - `named.tree_final_tree.nwk`: PastML's labeled-tree output (identical names to `final_tree.nwk` here).
    
    **For the other segments** (e.g., `results/PB2/all/` or `results/NP/all/`):
    - Same outputs as above, but combining all influenza subtypes
@@ -231,11 +236,18 @@ flu-usher/
     - Temporal subtrees compute per-tree median collection date for balanced early/late splits
     - Each subtree includes the root sequence plus matching samples
 
-18. **Create visualizations** (usher_to_taxonium):
+18. **Infer per-node host states** (PastML, `prepare_host_annotation.py`):
+    - Builds a 2-column annotation table from `combined_metadata_augmented.csv` mapping `isolate_id → host_group`
+    - Runs PastML with the DOWNPASS parsimony method on `final_tree.nwk` to reconstruct `host_group` for every internal node
+    - **Inputs:** `final_tree.nwk`, `combined_metadata_augmented.csv`
+    - **Outputs:** `host_ancestral/combined_ancestral_states.tab` (per-node host_group; node IDs match `final_tree.pb.gz`), `host_ancestral/host_tree.html` (interactive viz), `host_ancestral/named.tree_final_tree.nwk`
+    - Ambiguous internals appear on multiple rows of `combined_ancestral_states.tab` (one per equally-parsimonious state)
+
+19. **Create visualizations** (usher_to_taxonium):
     - Converts final tree and all subtrees to Taxonium format
     - Incorporates metadata (including host, geographic, and temporal groups) for interactive exploration
 
-19. **Execute analysis notebooks** (jupyter nbconvert):
+20. **Execute analysis notebooks** (jupyter nbconvert):
     - Runs analysis notebooks after all pipeline outputs are complete
     - Generates HTML reports in `results/notebooks/`
     - Includes metadata analysis and alignment statistics

--- a/Snakefile
+++ b/Snakefile
@@ -69,6 +69,15 @@ rule all:
         # Newick trees for other segments (all subtypes combined)
         expand("results/{segment}/all/final_tree.nwk",
                segment=[s for s in config["segments"] if s not in ["HA", "NA"]]),
+        # Per-node host inference for HA segments by subtype
+        expand("results/HA/{subtype}/host_ancestral/combined_ancestral_states.tab",
+               subtype=config["ha_subtypes"]),
+        # Per-node host inference for NA segments by subtype
+        expand("results/NA/{subtype}/host_ancestral/combined_ancestral_states.tab",
+               subtype=config["na_subtypes"]),
+        # Per-node host inference for other segments (all subtypes combined)
+        expand("results/{segment}/all/host_ancestral/combined_ancestral_states.tab",
+               segment=[s for s in config["segments"] if s not in ["HA", "NA"]]),
         # Executed analysis notebooks
         "results/notebooks/analyze_metadata.done",
         "results/notebooks/analyze_alignments.done",
@@ -713,6 +722,49 @@ rule extract_final_newick:
     shell:
         """
         matUtils extract -i {input.tree} -t {output.newick} &> {log}
+        """
+
+# Build a 2-column (isolate_id, host_group) CSV for PastML's --data argument
+rule prepare_host_annotation:
+    conda: "envs/python.yaml"
+    input:
+        metadata="results/combined_metadata_augmented.csv"
+    output:
+        "results/{segment}/{subtype}/host_annotation.csv"
+    log:
+        "logs/{segment}/{subtype}/prepare_host_annotation.log"
+    shell:
+        """
+        python scripts/prepare_host_annotation.py {input.metadata} {output} &> {log}
+        """
+
+# Infer host_group at every internal node via PastML / DOWNPASS parsimony.
+# PastML preserves matUtils' node names verbatim when every node is uniquely named,
+# so the 'node' column of combined_ancestral_states.tab joins directly to final_tree.pb.gz.
+rule infer_node_hosts:
+    conda: "envs/pastml.yaml"
+    input:
+        tree="results/{segment}/{subtype}/final_tree.nwk",
+        annotation="results/{segment}/{subtype}/host_annotation.csv"
+    output:
+        states="results/{segment}/{subtype}/host_ancestral/combined_ancestral_states.tab",
+        html="results/{segment}/{subtype}/host_ancestral/host_tree.html"
+    params:
+        work_dir="results/{segment}/{subtype}/host_ancestral"
+    log:
+        "logs/{segment}/{subtype}/infer_node_hosts.log"
+    shell:
+        """
+        pastml \
+            --tree {input.tree} \
+            --data {input.annotation} \
+            --data_sep , \
+            --id_index 0 \
+            --columns host_group \
+            --prediction_method DOWNPASS \
+            --work_dir {params.work_dir} \
+            --html_compressed {output.html} \
+            &> {log}
         """
 
 # Execute analysis notebooks and generate HTML reports

--- a/Snakefile
+++ b/Snakefile
@@ -724,15 +724,16 @@ rule extract_final_newick:
         matUtils extract -i {input.tree} -t {output.newick} &> {log}
         """
 
-# Build a 2-column (isolate_id, host_group) CSV for PastML's --data argument
+# Build a 2-column (isolate_id, host_group) CSV for PastML's --data argument.
+# Single global file shared across all (segment, subtype) PastML runs.
 rule prepare_host_annotation:
     conda: "envs/python.yaml"
     input:
         metadata="results/combined_metadata_augmented.csv"
     output:
-        "results/{segment}/{subtype}/host_annotation.csv"
+        "results/host_annotation.csv"
     log:
-        "logs/{segment}/{subtype}/prepare_host_annotation.log"
+        "logs/prepare_host_annotation.log"
     shell:
         """
         python scripts/prepare_host_annotation.py {input.metadata} {output} &> {log}
@@ -745,7 +746,7 @@ rule infer_node_hosts:
     conda: "envs/pastml.yaml"
     input:
         tree="results/{segment}/{subtype}/final_tree.nwk",
-        annotation="results/{segment}/{subtype}/host_annotation.csv"
+        annotation="results/host_annotation.csv"
     output:
         states="results/{segment}/{subtype}/host_ancestral/combined_ancestral_states.tab",
         html="results/{segment}/{subtype}/host_ancestral/host_tree.html"

--- a/envs/pastml.yaml
+++ b/envs/pastml.yaml
@@ -1,0 +1,10 @@
+name: pastml
+
+channels:
+  - https://prefix.dev/conda-forge
+  - https://prefix.dev/bioconda
+  - nodefaults
+
+dependencies:
+  - python=3.10
+  - pastml

--- a/scripts/prepare_host_annotation.py
+++ b/scripts/prepare_host_annotation.py
@@ -1,0 +1,25 @@
+"""
+Emit a 2-column (isolate_id, host_group) CSV from the augmented metadata, for
+PastML's --data argument.
+"""
+
+import argparse
+
+import pandas as pd
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract isolate_id, host_group from augmented metadata for PastML."
+    )
+    parser.add_argument("input", help="Input CSV (combined_metadata_augmented.csv)")
+    parser.add_argument("output", help="Output 2-column CSV (isolate_id, host_group)")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.input, usecols=["isolate_id", "host_group"])
+    df.to_csv(args.output, index=False)
+    print(f"Wrote {len(df)} rows to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds per-node host_group reconstruction via PastML / DOWNPASS parsimony for every internal node of `final_tree.pb.gz`.
- Two new rules (`prepare_host_annotation`, `infer_node_hosts`) wired into `rule all`; new `envs/pastml.yaml` + `scripts/prepare_host_annotation.py`.
- Output: `host_ancestral/combined_ancestral_states.tab` keyed by matUtils' `node_N` IDs (which round-trip through `matUtils extract -t` to the same labels as `final_tree.nwk`, so the table joins directly to the MAT).

Closes #29.

## Test plan
- [x] Smoke run on `NA/N9` end-to-end via snakemake; both new rules execute cleanly under `--use-conda`.
- [x] Pipeline run on all 16 trees (HA H1/H3/H5/H7/H9, NA N1/N2/N6/N8/N9, PB2/PB1/PA/NP/MP/NS).
- [x] Per-tree sanity checks (script: `verify_host_ancestral.py`):
  - `unique_nodes_in_TSV == n_leaves + n_internals` of `final_tree.pb.gz`.
  - DOWNPASS ambiguity rows accounted for (most internals unambiguous; 12–529 extra rows per tree).
  - `host_group` values drawn only from `{human, avian, swine, bovine, other}`.
  - **Clade-set equality**: every named node in PastML's `named.tree_final_tree.nwk` defines the same descendant-leaf set as in `final_tree.nwk` — confirms PastML preserved both names and topology on every tree.
- [x] matUtils determinism: two independent `matUtils extract -t` calls on the same `final_tree.pb.gz` produce byte-identical newicks. Combined with the clade-equality check, this means PastML's TSV node IDs are consistent with `final_tree.pb.gz` and `final_tree.nwk` end-to-end.
- [x] Visual spot-check: a known all-swine clade (e.g. `node_1780` in HA/H1, 39 leaves) is correctly inferred as `swine`. Note: Taxonium uses an independent integer numbering scheme for internal nodes — the TSV's `node_N` IDs do **not** match Taxonium's display IDs. Join PastML output through `final_tree.nwk`, not Taxonium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)