### PR TITLE
Act on the #51 review follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,18 +49,22 @@ snakemake --cores 8 --use-conda <target> --forcerun <rule_name>
 
 # `--rerun-triggers mtime` narrows the default trigger set (mtime, params,
 # input, software-env, code) down to mtime alone, which disables params-based
-# invalidation. No rule declares config.yaml as an input any more, so under
-# mtime-only a config edit invalidates NOTHING and every affected output goes
-# quietly stale. Use it for a quick dry run, not to decide whether real work is
-# up to date.
+# invalidation. Only execute_analyze_alignments and execute_analyze_dags still
+# declare config.yaml as an input -- their notebooks open it directly, which
+# nothing but an mtime dependency can track -- so under mtime-only a config
+# edit re-runs those two and nothing else, and every substantive output goes
+# quietly stale. Measured: a reroot edit under mtime-only schedules 3 jobs.
+# Use it for a quick dry run, not to decide whether real work is up to date.
 #
 # Under the default triggers, config invalidation is precise: each rule names
 # the config values it consumes in `params:`, so editing a reroot target
 # re-runs the reroot rules and leaves the alignments alone. It did not used to
 # be -- download_all_references took config.yaml as an input at the head of the
 # DAG, so any edit re-downloaded the references and cascaded through
-# everything. Measured before that change: one reroot target re-ran 1235 of
-# 1235 jobs, identically with and without the params trigger.
+# everything. Measured before that change: one reroot target re-ran 1235 of the
+# DAG's 1240 jobs, identically with and without the params trigger. (The five
+# spared are parse_gisaid_data, augment_metadata, the two annotation rules and
+# input_data_md5sums -- everything expensive re-derived.)
 snakemake -n --use-conda <target> --rerun-triggers mtime
 
 # Generate workflow visualization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ conda env create -f environment.yml
 conda activate flu-usher
 ```
 
-Per-step dependencies are managed via separate conda environments in `envs/` (ete3, fatovcf, historydag, larch, nextclade, pastml, python, taxonium, usher). Snakemake creates and activates these automatically when run with `--use-conda`.
+Per-step dependencies are managed via separate conda environments in `envs/` (ete3, fatovcf, historydag, nextclade, pastml, python, taxonium, usher; larch is not among them -- see the note on `tree_to_dag`). Snakemake creates and activates these automatically when run with `--use-conda`.
 
 ### Running the Pipeline
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ The pipeline expects GISAID data in each input directory:
 
 ### Important Notes
 
-- Tests live in six `scripts/test_*.py` modules (179 unittest tests: curate 91, rebase_mat_root 33, check_tree_sequences 30, parse_gisaid 11, reroot_newick 8, create_samples 6). Run them with `python -m unittest discover` from within `scripts/`. Under `envs/python.yaml` that reports `OK (skipped=8)`: `test_reroot_newick.py` is `skipIf`-guarded because ete3 lives in its own env, so run it separately under `envs/ete3.yaml` to actually exercise those 8 — `OK (skipped=N)` otherwise reads like a pass. No linting setup currently exists, and 11 of the 17 script modules are untested.
+- Tests live in seven `scripts/test_*.py` modules (202 unittest tests: curate 91, check_tree_sequences 31, rebase_mat_root 30, utils 18, parse_gisaid 15, create_samples 9, reroot_newick 8). Run them with `python -m unittest discover` from within `scripts/`. Under `envs/python.yaml` that reports `OK (skipped=8)`: `test_reroot_newick.py` is `skipIf`-guarded because ete3 lives in its own env, so run it separately under `envs/ete3.yaml` to actually exercise those 8 — `OK (skipped=N)` otherwise reads like a pass. No linting setup currently exists, and 10 of the 17 script modules are untested.
 - The pipeline uses compressed outputs (.xz, .gz) to save disk space
 - All logs are saved in the `logs/` directory organized by segment/subtype
 - The pipeline can process multiple influenza subtypes simultaneously

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ The pipeline expects GISAID data in each input directory:
 
 ### Important Notes
 
-- Tests live in seven `scripts/test_*.py` modules (202 unittest tests: curate 91, check_tree_sequences 31, rebase_mat_root 30, utils 18, parse_gisaid 15, create_samples 9, reroot_newick 8). Run them with `python -m unittest discover` from within `scripts/`. Under `envs/python.yaml` that reports `OK (skipped=8)`: `test_reroot_newick.py` is `skipIf`-guarded because ete3 lives in its own env, so run it separately under `envs/ete3.yaml` to actually exercise those 8 — `OK (skipped=N)` otherwise reads like a pass. No linting setup currently exists, and 10 of the 17 script modules are untested.
+- Tests live in nine `scripts/test_*.py` modules (221 unittest tests: curate 91, check_tree_sequences 31, rebase_mat_root 30, utils 21, parse_gisaid 15, extract_root_sequence 13, create_samples 9, reroot_newick 8, config_params_sync 3). Run them with `python -m unittest discover` from within `scripts/`. Under `envs/python.yaml` that reports `OK (skipped=8)`: `test_reroot_newick.py` is `skipIf`-guarded because ete3 lives in its own env, so run it separately under `envs/ete3.yaml` to actually exercise those 8 — `OK (skipped=N)` otherwise reads like a pass. No linting setup currently exists, and 9 of the 17 script modules are untested.
 - The pipeline uses compressed outputs (.xz, .gz) to save disk space
 - All logs are saved in the `logs/` directory organized by segment/subtype
 - The pipeline can process multiple influenza subtypes simultaneously

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,17 +48,19 @@ snakemake --cores 8 --use-conda results/HA/H5/geographic_trees/north_america_tre
 snakemake --cores 8 --use-conda <target> --forcerun <rule_name>
 
 # `--rerun-triggers mtime` narrows the default trigger set (mtime, params,
-# input, software-env, code) down to mtime alone, disabling params-based
-# invalidation. That is safe for config.yaml, contrary to what this file used
-# to say: download_all_references passes config.yaml to its script, so it is a
-# real input, and it sits at the head of the DAG. Editing any config value
-# changes that file's mtime, re-runs it, and cascades through the reference
-# files to everything -- measured, one reroot target changed re-runs 1235 of
-# 1235 jobs, identically with and without the params trigger.
+# input, software-env, code) down to mtime alone, which disables params-based
+# invalidation. No rule declares config.yaml as an input any more, so under
+# mtime-only a config edit invalidates NOTHING and every affected output goes
+# quietly stale. Use it for a quick dry run, not to decide whether real work is
+# up to date.
 #
-# The flip side is that config.yaml invalidation is maximally blunt: there is
-# no such thing as editing one config value and re-running only what depends
-# on it. Expect a full re-derivation from any config edit.
+# Under the default triggers, config invalidation is precise: each rule names
+# the config values it consumes in `params:`, so editing a reroot target
+# re-runs the reroot rules and leaves the alignments alone. It did not used to
+# be -- download_all_references took config.yaml as an input at the head of the
+# DAG, so any edit re-downloaded the references and cascaded through
+# everything. Measured before that change: one reroot target re-ran 1235 of
+# 1235 jobs, identically with and without the params trigger.
 snakemake -n --use-conda <target> --rerun-triggers mtime
 
 # Generate workflow visualization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,15 +48,17 @@ snakemake --cores 8 --use-conda results/HA/H5/geographic_trees/north_america_tre
 snakemake --cores 8 --use-conda <target> --forcerun <rule_name>
 
 # `--rerun-triggers mtime` narrows the default trigger set (mtime, params,
-# input, software-env, code) down to mtime alone. That disables params-based
-# invalidation, and six rules read config.yaml values through `params:`
-# without declaring config.yaml as an input -- create_newick's tree_sample_seed,
-# curate_and_extract_coding_seqs' max_frac_gaps/max_frac_ambig,
-# parse_gisaid_data's segment and subtype lists, and the three root rules
-# (create_root_samples_file, extract_root_mutations, create_root_fasta).
-# Under mtime-only, editing any of those in config.yaml leaves the affected
-# outputs stale with no warning. Use it for a quick dry run, not to decide
-# whether real work is up to date.
+# input, software-env, code) down to mtime alone, disabling params-based
+# invalidation. That is safe for config.yaml, contrary to what this file used
+# to say: download_all_references passes config.yaml to its script, so it is a
+# real input, and it sits at the head of the DAG. Editing any config value
+# changes that file's mtime, re-runs it, and cascades through the reference
+# files to everything -- measured, one reroot target changed re-runs 1235 of
+# 1235 jobs, identically with and without the params trigger.
+#
+# The flip side is that config.yaml invalidation is maximally blunt: there is
+# no such thing as editing one config value and re-running only what depends
+# on it. Expect a full re-derivation from any config edit.
 snakemake -n --use-conda <target> --rerun-triggers mtime
 
 # Generate workflow visualization

--- a/Snakefile
+++ b/Snakefile
@@ -352,6 +352,14 @@ rule optimize_tree:
         """
 
 # Convert optimized trees to DAGs
+# larch has no `conda:` directive, and snakemake --lint flags both rules for it.
+# That is accepted, not an oversight: larch is built from source into the main
+# flu-usher environment (environment.yml carries its build and runtime deps, not
+# larch itself), currently v0.1.3, built 2025-10-27. envs/larch.yaml used to sit
+# here pointing at the packaged larch-phylo, which is only 0.1.0 -- adopting it
+# would have silently downgraded the tree builder, so it was deleted rather than
+# wired up. Packaging larch properly is a separate change that has to be
+# validated against the trees it produces.
 rule tree_to_dag:
     input:
         tree="results/{segment}/{subtype}/randomized_{n}/opt_tree.pb.gz",
@@ -371,7 +379,8 @@ rule tree_to_dag:
             &> {log}
         """
 
-# Use larch to merge multiple DAGs into a single DAG
+# Use larch to merge multiple DAGs into a single DAG.
+# No `conda:` -- see the note on tree_to_dag.
 rule larch_merge:
     input:
         dags=expand("results/{{segment}}/{{subtype}}/randomized_{n}/dag.pb",
@@ -493,7 +502,6 @@ rule reroot_newick:
     conda: "envs/ete3.yaml"
     input:
         newick="results/{segment}/{subtype}/sampled_tree.nh",
-        config="config.yaml",
         script=script_deps("reroot_newick.py")
     output:
         "results/{segment}/{subtype}/rerooted_tree.nh"
@@ -516,8 +524,7 @@ rule create_final_mat:
     conda: "envs/usher.yaml"
     input:
         tree=final_mat_source,
-        vcf="results/{segment}/{subtype}/randomized_0/msa.vcf",
-        config="config.yaml"
+        vcf="results/{segment}/{subtype}/randomized_0/msa.vcf"
     output:
         "results/{segment}/{subtype}/reference_origin_tree.pb.gz"
     params:
@@ -616,7 +623,6 @@ rule check_tree_sequences:
         reference="results/{segment}/{subtype}/curated_reference.fasta",
         final_origin="results/{segment}/{subtype}/final_tree_root.fasta",
         vcf="results/{segment}/{subtype}/randomized_0/msa.vcf",
-        config="config.yaml",
         script=script_deps("check_tree_sequences.py")
     output:
         "results/{segment}/{subtype}/reroot_sequence_check.txt"
@@ -1008,7 +1014,6 @@ rule execute_analyze_metadata:
     conda: "envs/python.yaml"
     input:
         notebook="notebooks/analyze_metadata.ipynb",
-        config_file="config.yaml",
         metadata="results/combined_metadata_augmented.csv",
         trees=ALL_FINAL_TREES
     output:
@@ -1031,6 +1036,7 @@ rule execute_analyze_metadata:
 # manifest. Output lines follow the standard `md5sum` format:
 # "<hash>  <path>", one file per line.
 rule input_data_md5sums:
+    conda: "envs/python.yaml"
     input:
         INPUT_DATA_FILES
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -180,18 +180,27 @@ rule download_all_references:
               expand("results/{segment}/all/reference/pathogen.json",
                      segment=[s for s in config["segments"] if s not in ["HA", "NA"]])
     input:
-        # Declared as an input, not just a params path: the accessions live in
-        # config.yaml, so editing one must re-trigger the download.
-        config_file="config.yaml",
         script=script_deps("download_ref_seq.py")
     params:
+        # The values this rule actually consumes, declared so the default
+        # `params` rerun-trigger hashes them. config.yaml is deliberately NOT an
+        # input: this rule sits at the head of the DAG, so depending on the
+        # file's mtime made every config edit -- a reroot target, a seed, a
+        # filtering threshold -- re-download the references and re-derive the
+        # whole pipeline. Measured before this change: one reroot target
+        # changed re-ran 1235 of 1235 jobs. Naming the values instead keeps the
+        # trigger precise; the script still reads the file for the rest.
+        references=config["references"],
+        ha_subtypes=config["ha_subtypes"],
+        na_subtypes=config["na_subtypes"],
+        segments=config["segments"],
         wait_time=30
     log:
         "logs/download_all_references.log"
     shell:
         """
         python scripts/download_ref_seq.py \
-            --config {input.config_file} \
+            --config config.yaml \
             --output-base-dir results \
             --wait-time {params.wait_time} \
             &> {log}

--- a/Snakefile
+++ b/Snakefile
@@ -363,11 +363,18 @@ rule optimize_tree:
 # Convert optimized trees to DAGs
 # larch has no `conda:` directive, and snakemake --lint flags both rules for it.
 # That is accepted, not an oversight: larch is built from source into the main
-# flu-usher environment (environment.yml carries its build and runtime deps, not
-# larch itself), currently v0.1.3, built 2025-10-27. envs/larch.yaml used to sit
-# here pointing at the packaged larch-phylo, which is only 0.1.0 -- adopting it
-# would have silently downgraded the tree builder, so it was deleted rather than
-# wired up. Packaging larch properly is a separate change that has to be
+# flu-usher environment (environment.yml carries its build and runtime deps,
+# not larch itself), from commit 0ac4146, built 2025-10-27.
+#
+# envs/larch.yaml used to sit here pointing at the packaged larch-phylo, and was
+# deleted rather than wired up. Note the package's "0.1.0" version string is a
+# stale VERSION-file fallback -- conda-build strips .git, so its `git describe`
+# never runs -- not a lower release: it is built from c2e75a2, which is the
+# v0.1.3 tag. The real gap is the 5 commits from there to 0ac4146, and adopting
+# it would not have degraded anything quietly, it would have broken outright:
+# fb1bb78 is what added VCF support to larch-dagutil, so the packaged binary has
+# no -v option and larch_merge below passes one. It also pins python_abi 3.8 and
+# boost-cpp 1.76. Packaging larch properly is a separate change that has to be
 # validated against the trees it produces.
 rule tree_to_dag:
     input:

--- a/envs/larch.yaml
+++ b/envs/larch.yaml
@@ -1,9 +1,0 @@
-name: larch
-
-channels:
-  - https://prefix.dev/conda-forge
-  - https://prefix.dev/matsengrp
-  - nodefaults
-
-dependencies:
-  - larch-phylo

--- a/scripts/check_tree_sequences.py
+++ b/scripts/check_tree_sequences.py
@@ -117,6 +117,16 @@ def root_children(newick):
     Hand-rolled rather than via ete3 so this stays in envs/python.yaml: loading
     a 130k-leaf tree just to read two names is not worth a second conda env in
     the rule.
+
+    Scanning for delimiters like this would mis-parse a label containing '(',
+    ')' or ':'. No such label reaches here, and that is enforced rather than
+    assumed: sanitize_id() in utils.py strips [ ] ( ) : ; , ' . from every
+    sequence ID, and curate_and_extract_coding_seqs.py applies it upstream of
+    everything that becomes a leaf; internal names are internal_<id> from
+    convert_DAG_protobuf_to_newick_samples.py. Checked against the shipped
+    trees: 0 of 84,664 labels in HA/H7 and NA/N1 contain any of them. Newick
+    comments in [...] are likewise not handled, and matUtils does not emit
+    them. Anything feeding this an arbitrary newick needs a real parser.
     """
     text = newick.strip()
     end = text.rfind(")")
@@ -278,7 +288,13 @@ def main():
             b = {p: v for p, v in final[sample].items() if p not in skip}
             excluded_sites += len(skip)
             if a != b:
-                sites = sorted(set(a) ^ set(b)) or sorted(p for p in a if a[p] != b.get(p))
+                # Both kinds of difference, not just the first kind that
+                # happens to be non-empty: a sample can have a position called
+                # in one tree and not the other *and* a position called in
+                # both with different bases. Reporting only the former sends
+                # whoever debugs this looking at the wrong sites.
+                sites = sorted(set(a) ^ set(b)
+                               | {p for p in set(a) & set(b) if a[p] != b[p]})
                 differing[sample] = sites
 
     with open(args.output, "w") as handle:

--- a/scripts/check_tree_sequences.py
+++ b/scripts/check_tree_sequences.py
@@ -45,22 +45,14 @@ cannot quietly hollow out the check.
 import argparse
 import sys
 
-from utils import setup_logging
+from utils import iter_path_mutations, read_reference, setup_logging
 
 logger = setup_logging(__name__)
 
 
-def read_reference(path):
+def reference_positions(path):
     """Return {1-based position: base} for the single record in a FASTA file."""
-    seq = []
-    with open(path) as handle:
-        for line in handle:
-            if line.startswith(">"):
-                if seq:
-                    break
-                continue
-            seq.append(line.strip())
-    return {i: base.upper() for i, base in enumerate("".join(seq), start=1)}
+    return {i: base for i, base in enumerate(read_reference(path), start=1)}
 
 
 def compose(path_field, ref, origin_diff=None):
@@ -78,13 +70,8 @@ def compose(path_field, ref, origin_diff=None):
     `ref` and stay comparable. Empty for a tree already on the reference.
     """
     alleles = {}
-    for chunk in path_field.split():
-        _, _, muts = chunk.partition(":")
-        for mut in muts.split(","):
-            if not mut:
-                continue
-            pos = int(mut[1:-1])
-            alleles[pos] = mut[-1]
+    for _, position, mutant in iter_path_mutations(path_field):
+        alleles[position] = mutant
     if origin_diff:
         # Positions where the origin already differs from ref and the path says
         # nothing: the sample inherits the origin's base, which is a difference.
@@ -215,7 +202,7 @@ def main():
             sys.exit(1)
         logger.info(f"Final tree is rooted at '{args.expect_root}'")
 
-    ref = read_reference(args.reference)
+    ref = reference_positions(args.reference)
 
     # The final tree may have been rebased onto its own root, in which case its
     # mutations are recorded against that sequence rather than the reference.
@@ -223,7 +210,7 @@ def main():
     # the whole reason rebasing is bookkeeping rather than a change of content.
     final_origin_diff = {}
     if args.final_origin:
-        origin = read_reference(args.final_origin)
+        origin = reference_positions(args.final_origin)
         if len(origin) != len(ref):
             logger.error(
                 f"final origin spans {len(origin)} positions, reference "

--- a/scripts/check_tree_sequences.py
+++ b/scripts/check_tree_sequences.py
@@ -119,14 +119,26 @@ def root_children(newick):
     the rule.
 
     Scanning for delimiters like this would mis-parse a label containing '(',
-    ')' or ':'. No such label reaches here, and that is enforced rather than
-    assumed: sanitize_id() in utils.py strips [ ] ( ) : ; , ' . from every
-    sequence ID, and curate_and_extract_coding_seqs.py applies it upstream of
-    everything that becomes a leaf; internal names are internal_<id> from
-    convert_DAG_protobuf_to_newick_samples.py. Checked against the shipped
-    trees: 0 of 84,664 labels in HA/H7 and NA/N1 contain any of them. Newick
-    comments in [...] are likewise not handled, and matUtils does not emit
-    them. Anything feeding this an arbitrary newick needs a real parser.
+    ')' or ':'. No such label reaches here, from any of the three sources of
+    names in a matUtils newick:
+
+    - Leaves are sequence IDs, and sanitize_id() in utils.py strips
+      [ ] ( ) : ; , ' . from every one of them; curate_and_extract_coding_seqs
+      applies it upstream of everything that becomes a leaf. Enforced, not
+      assumed.
+    - Internal nodes are named node_N by matUtils itself, not by anything in
+      this repo. (The internal_<id> names that
+      convert_DAG_protobuf_to_newick_samples writes appear in sampled_tree.nh
+      and rerooted_tree.nh, which this function never reads.)
+    - Condensed nodes are node_N_condensed_M_leaves, written by usher -- 529 of
+      them across 15 of the 16 shipped trees. These bypass sanitize_id
+      entirely; they are safe because usher composes them from digits and
+      underscores, not because anything strips them.
+
+    Checked against the shipped trees: 0 risky characters in 113,434 labels
+    across HA/H7 and NA/N1, of which 84,664 are leaves. Newick comments in
+    [...] are likewise not handled, and matUtils does not emit them. Anything
+    feeding this an arbitrary newick needs a real parser.
     """
     text = newick.strip()
     end = text.rfind(")")

--- a/scripts/extract_root_sequence.py
+++ b/scripts/extract_root_sequence.py
@@ -2,10 +2,12 @@
 Extract and infer root sequence from tree mutation paths with validation against MSA.
 """
 import argparse
+import sys
+
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from utils import open_sequence_file, setup_logging
+from utils import open_sequence_file, parse_mutation, setup_logging
 
 logger = setup_logging(__name__)
 
@@ -37,18 +39,30 @@ def parse_mutation_path(paths_file, new_root_name):
 
 
 def apply_mutations(reference_seq, mutations):
-    """Apply mutations to reference sequence."""
+    """Apply a root-to-tip mutation path to the reference, 1-based positions.
+
+    A parent-base mismatch means the path and the reference are not the pair we
+    think they are, so the sequence this builds would be wrong. It used to warn
+    and carry on; validate_sequences() would then fail further downstream on
+    the consequence rather than the cause. Fail here instead, matching
+    rebase_mat_root.root_sequence(), which does the same job from the protobuf.
+    """
     seq = list(str(reference_seq))
-    for mut in mutations:
-        orig_base = mut[0]
-        new_base = mut[-1]
-        pos = int(mut[1:-1]) - 1  # Convert to 0-based
-
-        # Validate original base matches
-        if seq[pos] != orig_base:
-            logger.warning(f"Expected {orig_base} at position {pos+1}, found {seq[pos]}")
-
-        seq[pos] = new_base
+    for token in mutations:
+        parent, position, mutant = parse_mutation(token)
+        index = position - 1
+        if not 0 <= index < len(seq):
+            logger.error(
+                f"mutation {token} is outside the {len(seq)}-base reference"
+            )
+            sys.exit(1)
+        if seq[index] != parent:
+            logger.error(
+                f"mutation {token} expects {parent} at position {position}, "
+                f"but the reference has {seq[index]}"
+            )
+            sys.exit(1)
+        seq[index] = mutant
     return ''.join(seq)
 
 

--- a/scripts/extract_root_sequence.py
+++ b/scripts/extract_root_sequence.py
@@ -7,7 +7,7 @@ import sys
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from utils import open_sequence_file, parse_mutation, setup_logging
+from utils import iter_path_mutations, open_sequence_file, setup_logging
 
 logger = setup_logging(__name__)
 
@@ -22,19 +22,24 @@ def extract_sequence_from_msa(msa_file, sequence_name):
 
 
 def parse_mutation_path(paths_file, new_root_name):
-    """Extract all mutations from the path to the new root."""
+    """Return the root-to-tip mutations for one sample, as parsed triples.
+
+    Tokenizing is delegated to utils.iter_path_mutations rather than repeated
+    here. The hand-rolled version this replaces split on ':' by index, which
+    raised a bare IndexError on a colon-less chunk instead of saying what was
+    wrong, and was a fourth copy of the format the shared parser exists to own.
+    """
     with open(paths_file) as f:
         for line in f:
-            parts = line.strip().split('\t')
-            if len(parts) == 2 and parts[0] == new_root_name:
-                # Parse mutation path
-                mutations = []
-                if parts[1]:  # Non-empty path
-                    for node in parts[1].split():
-                        node_muts = node.split(':')[1]
-                        if node_muts:
-                            mutations.extend(node_muts.split(','))
-                return mutations
+            # rstrip('\n'), not strip(): a sample whose path is empty writes
+            # "name\t\n", and strip() eats the tab, so the row split to one
+            # field and the sample was reported missing rather than
+            # mutation-free. Every root_paths.txt on disk has such a row -- the
+            # reference against itself -- so this only escaped notice because
+            # nothing ever looks that row up.
+            parts = line.rstrip('\n').split('\t')
+            if len(parts) >= 2 and parts[0] == new_root_name:
+                return list(iter_path_mutations(parts[1]))
     raise ValueError(f"Sample {new_root_name} not found in paths file")
 
 
@@ -48,8 +53,8 @@ def apply_mutations(reference_seq, mutations):
     rebase_mat_root.root_sequence(), which does the same job from the protobuf.
     """
     seq = list(str(reference_seq))
-    for token in mutations:
-        parent, position, mutant = parse_mutation(token)
+    for parent, position, mutant in mutations:
+        token = f"{parent}{position}{mutant}"
         index = position - 1
         if not 0 <= index < len(seq):
             logger.error(
@@ -108,8 +113,15 @@ def main():
         ref_record = next(SeqIO.parse(f, 'fasta'))
     logger.info(f"Loaded reference sequence: {ref_record.id} ({len(ref_record.seq)} bp)")
 
-    # Parse mutation path for new root
-    mutations = parse_mutation_path(args.paths, args.new_root_name)
+    # Parse mutation path for new root. Both failure modes -- the sample not
+    # being in the file, and a token the shared parser rejects -- are the
+    # pipeline's problem to report, not a traceback's: the other two failures
+    # in this script already exit(1) with an explanation, so match them.
+    try:
+        mutations = parse_mutation_path(args.paths, args.new_root_name)
+    except ValueError as error:
+        logger.error(f"could not read the path to {args.new_root_name}: {error}")
+        sys.exit(1)
     logger.info(f"Found {len(mutations)} mutations along path to {args.new_root_name}")
 
     # Apply mutations to reference sequence

--- a/scripts/rebase_mat_root.py
+++ b/scripts/rebase_mat_root.py
@@ -85,9 +85,11 @@ def root_branch_length(newick):
     makes it useful for checking that node_mutations[0] really is the root.
 
     Like zero_root_branch_length() below, this finds the root by scanning for
-    the last ')', which a label containing parens or colons would defeat.
-    Those characters cannot appear: sanitize_id() strips them upstream (see
-    check_tree_sequences.root_children for the full argument).
+    the last ')', which a label containing parens or colons would defeat. They
+    cannot appear here -- note this reads mat.newick from inside the protobuf,
+    where internal nodes are unnamed and only leaves and usher's condensed
+    nodes carry labels. See check_tree_sequences.root_children for the full
+    argument over all three sources of names.
     """
     text = newick.rstrip().rstrip(";")
     close = text.rfind(")")

--- a/scripts/rebase_mat_root.py
+++ b/scripts/rebase_mat_root.py
@@ -83,6 +83,11 @@ def root_branch_length(newick):
     Branch lengths in a MAT newick are mutation counts, so this is a second,
     independent encoding of len(node_mutations[0].mutation) -- which is what
     makes it useful for checking that node_mutations[0] really is the root.
+
+    Like zero_root_branch_length() below, this finds the root by scanning for
+    the last ')', which a label containing parens or colons would defeat.
+    Those characters cannot appear: sanitize_id() strips them upstream (see
+    check_tree_sequences.root_children for the full argument).
     """
     text = newick.rstrip().rstrip(";")
     close = text.rfind(")")
@@ -148,6 +153,8 @@ def rebase_onto_root(node_mutations):
     Kept separate from main() so it can be tested without the compiled schema,
     which lives in envs/taxonium; it needs only objects with .mutation lists.
     """
+    if not node_mutations:
+        raise ValueError("MAT has no node mutation lists, so it has no root")
     root = node_mutations[0]
     moved = {m.position: m.mut_nuc[0] for m in root.mutation}
     repointed = 0

--- a/scripts/rebase_mat_root.py
+++ b/scripts/rebase_mat_root.py
@@ -30,26 +30,13 @@ import argparse
 import gzip
 import sys
 
-from utils import setup_logging
+from utils import read_reference, setup_logging
 
 logger = setup_logging(__name__)
 
 # usher encodes nucleotides as indices into this string, verified against the
 # mutation paths matUtils writes (position 33 ref_nuc=0 mut_nuc=3 is "A33T").
 NUCLEOTIDES = "ACGT"
-
-
-def read_reference(path):
-    """Return the single sequence in a FASTA file, uppercased."""
-    parts = []
-    with open(path) as handle:
-        for line in handle:
-            if line.startswith(">"):
-                if parts:
-                    break
-                continue
-            parts.append(line.strip())
-    return "".join(parts).upper()
 
 
 def _schema():

--- a/scripts/test_check_tree_sequences.py
+++ b/scripts/test_check_tree_sequences.py
@@ -185,6 +185,22 @@ class EndToEndTestCase(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("sample sets differ", result.stderr)
 
+    def test_report_lists_both_kinds_of_differing_site(self):
+        """A key-set difference must not hide a same-key value difference.
+
+        EPI_A differs at position 1 (G vs C, called in both) and at position 3
+        (present only in the final tree). Reporting only the latter would send
+        someone debugging this to the wrong site.
+        """
+        sampled = "EPI_A\tnode_1:A1G\n"
+        final = "EPI_A\tnode_9:A1C,G3T\n"
+        result = self.run_check(sampled, final)
+        self.assertEqual(result.returncode, 1)
+        detail = [l for l in result.stderr.splitlines() if "EPI_A" in l]
+        self.assertTrue(detail, result.stderr)
+        self.assertIn("1", detail[-1])
+        self.assertIn("3", detail[-1])
+
     def test_extra_sample_in_final_tree_fails(self):
         """The other half of the mismatch check, OR'd into the same branch."""
         sampled = "EPI_A\tnode_1:A1G\n"

--- a/scripts/test_check_tree_sequences.py
+++ b/scripts/test_check_tree_sequences.py
@@ -196,10 +196,13 @@ class EndToEndTestCase(unittest.TestCase):
         final = "EPI_A\tnode_9:A1C,G3T\n"
         result = self.run_check(sampled, final)
         self.assertEqual(result.returncode, 1)
-        detail = [l for l in result.stderr.splitlines() if "EPI_A" in l]
-        self.assertTrue(detail, result.stderr)
-        self.assertIn("1", detail[-1])
-        self.assertIn("3", detail[-1])
+        # Assert the exact list from the report, not a substring of stderr:
+        # log lines carry a timestamp, and "14:30:16,636" contains both a "1"
+        # and a "3", so substring checks pass no matter what was reported.
+        # The old expression yields [3] here; this must distinguish them.
+        with open(os.path.join(self.tmp.name, "report.txt")) as handle:
+            report = handle.read()
+        self.assertIn("EPI_A: [1, 3]", report, report)
 
     def test_extra_sample_in_final_tree_fails(self):
         """The other half of the mismatch check, OR'd into the same branch."""

--- a/scripts/test_config_params_sync.py
+++ b/scripts/test_config_params_sync.py
@@ -1,0 +1,72 @@
+"""Guard the one place a config value can go stale without anyone noticing.
+
+Most rules hand their script a resolved value (`--root '{params.new_root}'`),
+so what Snakemake hashes for the params rerun-trigger is literally what the
+script uses, and the two cannot drift. download_all_references is the
+exception: it passes `--config config.yaml` and the script re-reads the file
+itself, so the rule's `params:` block is only Snakemake's *belief* about which
+values matter. Add a key to the script without adding it to the rule and
+editing that key silently rebuilds nothing -- the exact failure mode removing
+config.yaml-as-an-input was meant to eliminate, relocated somewhere harder to
+see.
+
+This asserts the belief matches the code.
+"""
+import os
+import re
+import unittest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT = os.path.join(REPO, "scripts", "download_ref_seq.py")
+SNAKEFILE = os.path.join(REPO, "Snakefile")
+
+
+def config_keys_read_by(path):
+    """Top-level config keys a script reads, from `config["key"]` occurrences."""
+    with open(path) as handle:
+        return set(re.findall(r'config\[["\'](\w+)["\']\]', handle.read()))
+
+
+def rule_params_block(name):
+    """The text of one rule's `params:` block, up to the next top-level field."""
+    with open(SNAKEFILE) as handle:
+        text = handle.read()
+    start = text.index(f"rule {name}:")
+    end = text.index("\nrule ", start + 1)
+    body = text[start:end]
+    params_at = body.index("\n    params:")
+    rest = body[params_at + 1:]
+    # Fields are indented four spaces; params entries are indented eight.
+    following = re.search(r"\n    (?!    )\w+:", rest)
+    return rest[:following.start()] if following else rest
+
+
+class DownloadReferencesParamsSyncTestCase(unittest.TestCase):
+    def test_every_config_key_the_script_reads_is_declared_as_a_param(self):
+        params = rule_params_block("download_all_references")
+        missing = sorted(k for k in config_keys_read_by(SCRIPT)
+                         if f"config[\"{k}\"]" not in params
+                         and f"config['{k}']" not in params)
+        self.assertEqual(
+            missing, [],
+            "download_ref_seq.py reads these config keys, but "
+            "download_all_references does not declare them in params:, so "
+            "editing one would not re-trigger the download: " + str(missing),
+        )
+
+    def test_the_script_actually_reads_some_config_keys(self):
+        """Guards the guard: a regex that matches nothing would pass silently."""
+        self.assertTrue(config_keys_read_by(SCRIPT))
+
+    def test_config_yaml_is_not_an_input_of_the_rule(self):
+        """If it becomes one again, this whole test stops being necessary."""
+        with open(SNAKEFILE) as handle:
+            text = handle.read()
+        start = text.index("rule download_all_references:")
+        body = text[start:text.index("\nrule ", start + 1)]
+        inputs = body[body.index("\n    input:"):body.index("\n    params:")]
+        self.assertNotIn("config.yaml", inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_create_samples_file.py
+++ b/scripts/test_create_samples_file.py
@@ -23,17 +23,21 @@ ROOT_ID = "EPI_ISL_ROOT"
 REFERENCE_ID = "REFERENCE"
 
 
-def write_inputs(tmpdir, rows):
+def write_inputs(tmpdir, rows, msa_only=()):
     """
     Build the three inputs the script reads.
 
     rows: list of (isolate_id, geographic_group) for the metadata. Every
     isolate_id also goes into the curated MSA, behind the reference.
+    msa_only: isolate_ids written to the MSA but left out of the metadata,
+    for exercising the "MSA and metadata are out of sync" check.
     """
     msa = os.path.join(tmpdir, "curated_msa.fasta.xz")
     with lzma.open(msa, "wt") as f:
         f.write(f">{REFERENCE_ID}\nACGT\n")
         for isolate_id, _ in rows:
+            f.write(f">{isolate_id}\nACGT\n")
+        for isolate_id in msa_only:
             f.write(f">{isolate_id}\nACGT\n")
 
     root = os.path.join(tmpdir, "curated_root.fasta")
@@ -50,9 +54,9 @@ def write_inputs(tmpdir, rows):
     return msa, root, metadata
 
 
-def run_script(tmpdir, rows, value, column="geographic_group"):
+def run_script(tmpdir, rows, value, column="geographic_group", msa_only=()):
     """Invoke main() as the rule does. Returns the output path."""
-    msa, root, metadata = write_inputs(tmpdir, rows)
+    msa, root, metadata = write_inputs(tmpdir, rows, msa_only=msa_only)
     output = os.path.join(tmpdir, "samples.txt")
     argv = [
         "create_samples_file.py",
@@ -66,6 +70,38 @@ def run_script(tmpdir, rows, value, column="geographic_group"):
     with mock.patch.object(sys, "argv", argv):
         create_samples_file.main()
     return output
+
+
+class TestMsaAndMetadataMustAgree(unittest.TestCase):
+    """A sample in the MSA but not the metadata means the two are out of sync.
+
+    A distinct fail-fast path from the empty-filter one, and a plausible real
+    failure: the MSA and the metadata are produced by different rules, so one
+    can be rebuilt without the other.
+    """
+
+    def test_msa_sample_missing_from_metadata_exits_nonzero(self):
+        rows = [("EPI_ISL_1", "asia")]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(SystemExit) as cm:
+                run_script(tmpdir, rows, value="asia", msa_only=["EPI_ISL_STRAY"])
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_msa_sample_missing_from_metadata_writes_nothing(self):
+        rows = [("EPI_ISL_1", "asia")]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = os.path.join(tmpdir, "samples.txt")
+            with self.assertRaises(SystemExit):
+                run_script(tmpdir, rows, value="asia", msa_only=["EPI_ISL_STRAY"])
+            self.assertFalse(os.path.exists(output),
+                             "wrote a samples file despite inconsistent inputs")
+
+    def test_matching_filter_still_passes_without_stray_samples(self):
+        """Control: the same inputs minus the stray sample must succeed."""
+        rows = [("EPI_ISL_1", "asia")]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = run_script(tmpdir, rows, value="asia")
+            self.assertTrue(os.path.exists(output))
 
 
 class TestZeroMatchesIsAnError(unittest.TestCase):

--- a/scripts/test_extract_root_sequence.py
+++ b/scripts/test_extract_root_sequence.py
@@ -1,0 +1,137 @@
+"""Tests for extract_root_sequence.py.
+
+The module had no tests at all while carrying the fail-fast branches that
+decide whether curated_root.fasta is trustworthy: a mutation path that does not
+match the reference it is applied to produces a wrong root sequence, and the
+root sequence is what every downstream tree is compared against.
+
+These run main() in-process, as the rule does, rather than reconstructing its
+argument handling.
+"""
+import lzma
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import extract_root_sequence
+from extract_root_sequence import apply_mutations, parse_mutation_path
+
+ROOT = "EPI_ISL_ROOT"
+# A(1) C(2) G(3) T(4) A(5) C(6) G(7) T(8) A(9) C(10)
+REFERENCE = "ACGTACGTAC"
+
+
+class ParseMutationPathTestCase(unittest.TestCase):
+    def write(self, text):
+        handle = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
+        handle.write(text)
+        handle.close()
+        self.addCleanup(os.unlink, handle.name)
+        return handle.name
+
+    def test_returns_parsed_triples_in_root_to_tip_order(self):
+        path = self.write(f"{ROOT}\tnode_1:A1G node_2:C2T,G3A\n")
+        self.assertEqual(
+            parse_mutation_path(path, ROOT),
+            [("A", 1, "G"), ("C", 2, "T"), ("G", 3, "A")],
+        )
+
+    def test_empty_path_is_no_mutations(self):
+        self.assertEqual(parse_mutation_path(self.write(f"{ROOT}\t\n"), ROOT), [])
+
+    def test_missing_sample_raises(self):
+        with self.assertRaises(ValueError):
+            parse_mutation_path(self.write("OTHER\tnode_1:A1G\n"), ROOT)
+
+    def test_malformed_token_raises_rather_than_mis_slicing(self):
+        """The shared parser's job; this asserts it is actually reached."""
+        with self.assertRaises(ValueError):
+            parse_mutation_path(self.write(f"{ROOT}\tnode_1:nonsense\n"), ROOT)
+
+
+class ApplyMutationsTestCase(unittest.TestCase):
+    def test_applies_in_order(self):
+        got = apply_mutations(REFERENCE, [("A", 1, "G"), ("T", 4, "C")])
+        self.assertEqual(got, "GCGCACGTAC")
+
+    def test_same_position_twice_uses_the_running_state(self):
+        """The second mutation's parent is the first one's result, not the ref."""
+        got = apply_mutations(REFERENCE, [("A", 1, "G"), ("G", 1, "T")])
+        self.assertEqual(got, "TCGTACGTAC")
+
+    def test_parent_base_mismatch_exits_nonzero(self):
+        with self.assertRaises(SystemExit) as cm:
+            apply_mutations(REFERENCE, [("T", 1, "G")])   # position 1 is A
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_position_past_end_exits_nonzero(self):
+        with self.assertRaises(SystemExit) as cm:
+            apply_mutations(REFERENCE, [("A", 99, "G")])
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_position_zero_exits_nonzero(self):
+        """1-based; 0 would write to index -1, silently hitting the last base."""
+        with self.assertRaises(SystemExit) as cm:
+            apply_mutations(REFERENCE, [("A", 0, "G")])
+        self.assertEqual(cm.exception.code, 1)
+
+
+class MainTestCase(unittest.TestCase):
+    """End to end, as the create_root_fasta rule invokes it."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def build(self, path_field, msa_seq=None):
+        d = self.tmp.name
+        ref = os.path.join(d, "ref.fasta")
+        with open(ref, "w") as f:
+            f.write(f">reference\n{REFERENCE}\n")
+        msa = os.path.join(d, "msa.fasta.xz")
+        with lzma.open(msa, "wt") as f:
+            f.write(f">{ROOT}\n{msa_seq if msa_seq else REFERENCE}\n")
+        paths = os.path.join(d, "paths.txt")
+        with open(paths, "w") as f:
+            f.write(f"{ROOT}\t{path_field}\n")
+        out = os.path.join(d, "root.fasta")
+        return ["extract_root_sequence.py", "--reference", ref, "--msa", msa,
+                "--paths", paths, "--new-root-name", ROOT, "--output", out], out
+
+    def test_no_mutations_reproduces_the_reference(self):
+        argv, out = self.build("")
+        with mock.patch.object(sys, "argv", argv):
+            extract_root_sequence.main()
+        with open(out) as f:
+            self.assertEqual(f.read().split("\n", 1)[1].replace("\n", ""), REFERENCE)
+
+    def test_malformed_token_exits_nonzero_without_a_traceback(self):
+        """A ValueError from the parser must become a clean exit, like the rest."""
+        argv, _ = self.build("node_1:nonsense")
+        with mock.patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit) as cm:
+                extract_root_sequence.main()
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_missing_sample_exits_nonzero(self):
+        argv, _ = self.build("")
+        argv[argv.index("--new-root-name") + 1] = "NOT_PRESENT"
+        with mock.patch.object(sys, "argv", argv):
+            with self.assertRaises(SystemExit) as cm:
+                extract_root_sequence.main()
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_mismatch_against_the_msa_is_fatal(self):
+        """validate_sequences guards the result even when the path applied."""
+        argv, _ = self.build("node_1:A1G", msa_seq="ACGTACGTAC")
+        with mock.patch.object(sys, "argv", argv):
+            with self.assertRaises(ValueError):
+                extract_root_sequence.main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_parse_gisaid_data.py
+++ b/scripts/test_parse_gisaid_data.py
@@ -285,14 +285,28 @@ class TestUnparseableSubtype(unittest.TestCase):
         self.assertEqual(read_records(out, "NA", "N1"), ["EPI_ISL_1"])
 
     def test_partial_subtype_is_not_half_matched(self):
-        """"H3" alone has no N part, so the regex must reject the whole thing."""
-        code, out = self.run_with(seq_id("HA", "EPI_ISL_2", "A_/_H3"))
+        """"H3" alone has no N part, so the regex must reject the whole thing.
+
+        H3 is deliberately CONFIGURED here. With it unconfigured, a regex that
+        half-matched and returned ("H3", None) would be dropped by the
+        unrelated "subtype not configured" branch, producing exactly the same
+        observable result as correct rejection -- so the test could not tell
+        the two apart. Configuring it means a half-match would visibly write
+        an HA/H3 record.
+        """
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, True)
+        records = self.GOOD + [
+            seq_id("HA", "EPI_ISL_3", "A_/_H3N2"),      # keeps H3 non-empty
+            seq_id("HA", "EPI_ISL_2", "A_/_H3"),        # the partial one
+        ]
+        code, out = run_parse(tmpdir, records,
+                              ["EPI_ISL_1", "EPI_ISL_2", "EPI_ISL_3"],
+                              ha_subtypes=["H1", "H3"], na_subtypes=["N1"])
         self.assertEqual(code, 0)
-        self.assertEqual(read_records(out, "HA", "H1"), ["EPI_ISL_1"])
-        self.assertFalse(
-            os.path.exists(os.path.join(out, "HA", "H3")),
-            "created an H3 directory from a subtype with no N part",
-        )
+        self.assertEqual(read_records(out, "HA", "H3"), ["EPI_ISL_3"],
+                         "EPI_ISL_2 was half-matched into H3 on a subtype "
+                         "with no N part")
 
     def test_internal_segment_ignores_the_subtype_entirely(self):
         """Internal segments group as 'all', so the H*N* parse never applies."""

--- a/scripts/test_parse_gisaid_data.py
+++ b/scripts/test_parse_gisaid_data.py
@@ -16,6 +16,7 @@ parsing itself is not what these tests are about.
 
 import lzma
 import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -246,6 +247,59 @@ class TestDuplicateHandling(unittest.TestCase):
                                   ha_subtypes=["H1"], na_subtypes=["N1"])
             self.assertEqual(code, 0)
             self.assertEqual(read_records(out, "HA", "H1"), ["EPI_ISL_1"])
+
+
+class TestUnparseableSubtype(unittest.TestCase):
+    """A subtype that is not H*N* is skipped, not crashed on and not guessed.
+
+    extract_ha_na_subtype() returns (None, None) for anything its regex misses,
+    and HA and NA records take separate branches on that. Real GISAID data
+    carries entries like "B / Victoria" that land here.
+
+    Every case supplies a full complement of parseable records, because
+    parse_gisaid_data exits nonzero if any configured combination produces
+    nothing -- a different guard, already covered elsewhere.
+    """
+
+    GOOD = [
+        seq_id("HA", "EPI_ISL_1", "A_/_H1N1"),
+        seq_id("NA", "EPI_ISL_1", "A_/_H1N1"),
+        seq_id("PB2", "EPI_ISL_1", "A_/_H1N1"),
+    ]
+    IDS = ["EPI_ISL_1", "EPI_ISL_2"]
+
+    def run_with(self, extra):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, True)
+        return run_parse(tmpdir, self.GOOD + [extra], self.IDS,
+                         ha_subtypes=["H1"], na_subtypes=["N1"])
+
+    def test_ha_record_with_unparseable_subtype_is_skipped(self):
+        code, out = self.run_with(seq_id("HA", "EPI_ISL_2", "B_/_Victoria"))
+        self.assertEqual(code, 0)
+        self.assertEqual(read_records(out, "HA", "H1"), ["EPI_ISL_1"])
+
+    def test_na_record_with_unparseable_subtype_is_skipped(self):
+        code, out = self.run_with(seq_id("NA", "EPI_ISL_2", "B_/_Yamagata"))
+        self.assertEqual(code, 0)
+        self.assertEqual(read_records(out, "NA", "N1"), ["EPI_ISL_1"])
+
+    def test_partial_subtype_is_not_half_matched(self):
+        """"H3" alone has no N part, so the regex must reject the whole thing."""
+        code, out = self.run_with(seq_id("HA", "EPI_ISL_2", "A_/_H3"))
+        self.assertEqual(code, 0)
+        self.assertEqual(read_records(out, "HA", "H1"), ["EPI_ISL_1"])
+        self.assertFalse(
+            os.path.exists(os.path.join(out, "HA", "H3")),
+            "created an H3 directory from a subtype with no N part",
+        )
+
+    def test_internal_segment_ignores_the_subtype_entirely(self):
+        """Internal segments group as 'all', so the H*N* parse never applies."""
+        code, out = self.run_with(seq_id("PB2", "EPI_ISL_2", "B_/_Victoria"))
+        self.assertEqual(code, 0)
+        self.assertEqual(sorted(read_records(out, "PB2", "all")),
+                         ["EPI_ISL_1", "EPI_ISL_2"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_rebase_mat_root.py
+++ b/scripts/test_rebase_mat_root.py
@@ -144,6 +144,11 @@ class RebaseOntoRootTestCase(unittest.TestCase):
         self.assertEqual((moved, repointed), ({}, 0))
         self.assertEqual(self.child.mutation[0].ref_nuc, A)
 
+    def test_empty_node_mutations_raises(self):
+        """A MAT with no node lists has no root; IndexError would not say so."""
+        with self.assertRaises(ValueError):
+            rebase_onto_root([])
+
     def test_is_idempotent(self):
         """Rebasing an already-rebased tree changes nothing further."""
         rebase_onto_root(self.nodes)

--- a/scripts/test_rebase_mat_root.py
+++ b/scripts/test_rebase_mat_root.py
@@ -7,14 +7,11 @@ protobuf. What is still uncovered here is the file-level round trip: load_mat,
 save_mat, and that the fields this script never touches (condensed_nodes,
 metadata) survive serialization. Those are exercised only by the pipeline.
 """
-import os
-import tempfile
 import unittest
 from types import SimpleNamespace
 
-from rebase_mat_root import (NUCLEOTIDES, read_reference, rebase_onto_root,
-                             root_branch_length, root_sequence,
-                             zero_root_branch_length)
+from rebase_mat_root import (NUCLEOTIDES, rebase_onto_root, root_branch_length,
+                             root_sequence, zero_root_branch_length)
 
 
 def mutation(position, par_nuc, *mut_nuc):
@@ -27,27 +24,6 @@ def mutation(position, par_nuc, *mut_nuc):
 
 
 A, C, G, T = (NUCLEOTIDES.index(b) for b in "ACGT")
-
-
-class ReadReferenceTestCase(unittest.TestCase):
-    def write(self, text):
-        handle = tempfile.NamedTemporaryFile("w", suffix=".fasta", delete=False)
-        handle.write(text)
-        handle.close()
-        self.addCleanup(os.unlink, handle.name)
-        return handle.name
-
-    def test_single_record(self):
-        self.assertEqual(read_reference(self.write(">r\nACGT\n")), "ACGT")
-
-    def test_wrapped_lines_are_joined(self):
-        self.assertEqual(read_reference(self.write(">r\nACGT\nAAGG\n")), "ACGTAAGG")
-
-    def test_stops_at_second_record(self):
-        self.assertEqual(read_reference(self.write(">a\nACGT\n>b\nTTTT\n")), "ACGT")
-
-    def test_uppercases(self):
-        self.assertEqual(read_reference(self.write(">r\nacgt\n")), "ACGT")
 
 
 class RootSequenceTestCase(unittest.TestCase):

--- a/scripts/test_utils.py
+++ b/scripts/test_utils.py
@@ -42,6 +42,19 @@ class ParseMutationTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_mutation("133G")
 
+    def test_non_ascii_letter_base_raises(self):
+        """str.isalpha() would accept this and write the omega into a FASTA."""
+        with self.assertRaises(ValueError):
+            parse_mutation("A33\u03a9")
+
+    def test_non_ascii_digit_position_raises(self):
+        """'\u00b2'.isdigit() is True but int() rejects it; fail here, not there."""
+        with self.assertRaises(ValueError):
+            parse_mutation("A\u00b2G")
+
+    def test_lowercase_bases_are_accepted(self):
+        self.assertEqual(parse_mutation("a33t"), ("a", 33, "t"))
+
 
 class IterPathMutationsTestCase(unittest.TestCase):
     def test_empty_path(self):

--- a/scripts/test_utils.py
+++ b/scripts/test_utils.py
@@ -1,0 +1,104 @@
+"""Tests for the shared helpers in utils.py.
+
+parse_mutation and iter_path_mutations replaced three hand-rolled parsers of
+the same `<parent base><position><new base>` format that disagreed about how
+much to validate. These cover the validation the strictest of them had, so the
+consolidation cannot quietly lose it.
+"""
+import os
+import tempfile
+import unittest
+
+from utils import iter_path_mutations, parse_mutation, read_reference
+
+
+class ParseMutationTestCase(unittest.TestCase):
+    def test_single_digit_position(self):
+        self.assertEqual(parse_mutation("A1G"), ("A", 1, "G"))
+
+    def test_multi_digit_position(self):
+        """The slice a hand-rolled mut[1:2] would get wrong."""
+        self.assertEqual(parse_mutation("C1042T"), ("C", 1042, "T"))
+
+    def test_gap_bases_are_allowed(self):
+        self.assertEqual(parse_mutation("-33T"), ("-", 33, "T"))
+        self.assertEqual(parse_mutation("A33-"), ("A", 33, "-"))
+
+    def test_iupac_ambiguity_is_allowed(self):
+        self.assertEqual(parse_mutation("A33R"), ("A", 33, "R"))
+
+    def test_too_short_raises(self):
+        for token in ("", "A", "A1"):
+            with self.subTest(token=token):
+                with self.assertRaises(ValueError):
+                    parse_mutation(token)
+
+    def test_non_numeric_position_raises(self):
+        with self.assertRaises(ValueError):
+            parse_mutation("AxxG")
+
+    def test_digit_base_raises(self):
+        """A digit where a base belongs means the position slice was wrong."""
+        with self.assertRaises(ValueError):
+            parse_mutation("133G")
+
+
+class IterPathMutationsTestCase(unittest.TestCase):
+    def test_empty_path(self):
+        self.assertEqual(list(iter_path_mutations("")), [])
+
+    def test_single_chunk(self):
+        self.assertEqual(list(iter_path_mutations("node_1:A1G")),
+                         [("A", 1, "G")])
+
+    def test_several_mutations_in_one_chunk(self):
+        self.assertEqual(list(iter_path_mutations("node_1:A1G,C3T")),
+                         [("A", 1, "G"), ("C", 3, "T")])
+
+    def test_root_to_tip_order_is_preserved(self):
+        """Later chunks must come last, so they can supersede earlier ones."""
+        got = list(iter_path_mutations("node_1:A1G node_2:G1T"))
+        self.assertEqual(got, [("A", 1, "G"), ("G", 1, "T")])
+
+    def test_chunk_with_no_mutations_is_skipped(self):
+        self.assertEqual(list(iter_path_mutations("node_1: node_2:A1G")),
+                         [("A", 1, "G")])
+
+    def test_node_name_containing_a_colon_raises(self):
+        """partition(':') splits once, so the rest is not a mutation token.
+
+        Node names here are EPI_ISL_<n> or internal_<id> and carry no colons,
+        so this is unreachable in practice; the point is that it fails loudly
+        rather than silently mis-parsing if the naming ever changes.
+        """
+        with self.assertRaises(ValueError):
+            list(iter_path_mutations("node:1:A1G"))
+
+    def test_malformed_mutation_raises(self):
+        with self.assertRaises(ValueError):
+            list(iter_path_mutations("node_1:nonsense"))
+
+
+class ReadReferenceTestCase(unittest.TestCase):
+    def write(self, text):
+        handle = tempfile.NamedTemporaryFile("w", suffix=".fasta", delete=False)
+        handle.write(text)
+        handle.close()
+        self.addCleanup(os.unlink, handle.name)
+        return handle.name
+
+    def test_single_record(self):
+        self.assertEqual(read_reference(self.write(">r\nACGT\n")), "ACGT")
+
+    def test_wrapped_lines_are_joined(self):
+        self.assertEqual(read_reference(self.write(">r\nACGT\nAAGG\n")), "ACGTAAGG")
+
+    def test_stops_at_second_record(self):
+        self.assertEqual(read_reference(self.write(">a\nACGT\n>b\nTTTT\n")), "ACGT")
+
+    def test_uppercases(self):
+        self.assertEqual(read_reference(self.write(">r\nacgt\n")), "ACGT")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -27,6 +27,62 @@ def setup_logging(name=None):
     return logging.getLogger(name if name is not None else __name__)
 
 
+def parse_mutation(token):
+    """Split a matUtils mutation token into (parent base, position, new base).
+
+    Tokens look like "A33T": the base in the parent, a 1-based position, and
+    the base in this node. Note the first character is the *parent's* base, not
+    the reference's -- they coincide only for mutations on the root.
+
+    Raises ValueError rather than returning something wrong, because the two
+    callers used to slice this format by hand and disagreed about how much to
+    check; that format has already produced one production bug (issue #49).
+    """
+    if len(token) < 3:
+        raise ValueError(f"malformed mutation token {token!r}: too short")
+    parent, position, mutant = token[0], token[1:-1], token[-1]
+    if not position.isdigit():
+        raise ValueError(f"malformed mutation token {token!r}: bad position")
+    # IUPAC codes and gaps are permitted; digits are not, since that would mean
+    # the position slice took a character it should not have.
+    for base in (parent, mutant):
+        if not (base.isalpha() or base == '-'):
+            raise ValueError(f"malformed mutation token {token!r}: bad base {base!r}")
+    return parent, int(position), mutant
+
+
+def iter_path_mutations(path_field):
+    """Yield (parent base, position, new base) from a `matUtils extract -S` path.
+
+    The field is space-separated `node:MUT,MUT` chunks in root-to-tip order.
+    Mutations come out in that order, so a later one at the same position
+    supersedes an earlier one, and a mutation followed by its back-mutation
+    cancels.
+    """
+    for chunk in path_field.split():
+        _, _, mutations = chunk.partition(":")
+        for token in mutations.split(","):
+            if token:
+                yield parse_mutation(token)
+
+
+def read_reference(path):
+    """Return the first sequence in a FASTA file as one uppercased string.
+
+    Deliberately not Bio.SeqIO: this is called from rules whose environments
+    carry no biopython, and the inputs are single-record reference FASTAs.
+    """
+    parts = []
+    with open(path) as handle:
+        for line in handle:
+            if line.startswith(">"):
+                if parts:
+                    break
+                continue
+            parts.append(line.strip())
+    return "".join(parts).upper()
+
+
 def open_sequence_file(path, mode='rt'):
     """
     Open a possibly-compressed sequence file in text mode.

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -7,6 +7,15 @@ import logging
 import lzma
 import re
 
+DIGITS = "0123456789"
+
+# IUPAC nucleotide codes plus the gap character, in both cases. matUtils only
+# ever writes ACGT for this pipeline's data -- 2,628,520 tokens checked across
+# all 16 combinations, no other character appears -- but a MAT can carry an
+# ambiguous state, so accepting the codes costs nothing and rejecting anything
+# outside the set is what makes the check worth having.
+BASES = frozenset("ACGTUNRYSWKMBDHV" + "acgtunryswkmbdhv" + "-")
+
 
 def setup_logging(name=None):
     """
@@ -41,12 +50,15 @@ def parse_mutation(token):
     if len(token) < 3:
         raise ValueError(f"malformed mutation token {token!r}: too short")
     parent, position, mutant = token[0], token[1:-1], token[-1]
-    if not position.isdigit():
+    # Both checks are deliberately charset-explicit rather than str.isdigit() /
+    # str.isalpha(), which accept any Unicode digit or letter: '2'.isdigit() is
+    # True for the superscript form that int() then rejects, and 'A33O'.isalpha()
+    # passes with a Greek omega that would be written straight into a FASTA.
+    # Failing at the parse boundary is the whole point of this function.
+    if not position or position.strip(DIGITS) != "":
         raise ValueError(f"malformed mutation token {token!r}: bad position")
-    # IUPAC codes and gaps are permitted; digits are not, since that would mean
-    # the position slice took a character it should not have.
     for base in (parent, mutant):
-        if not (base.isalpha() or base == '-'):
+        if base not in BASES:
             raise ValueError(f"malformed mutation token {token!r}: bad base {base!r}")
     return parent, int(position), mutant
 


### PR DESCRIPTION
Acts on most of #51, plus the config-precision problem that surfaced while measuring it. Five commits, each independently reviewable.

Everything here was verified against the shipped artifacts, not only unit tests — three of these touch code that produces `curated_root.fasta`, `final_tree_root.fasta`, and the gate report.

## Consolidate the mutation-path parsers (`84fccdc`)

Three functions parsed the same `<parent base><position><new base>` token format independently and disagreed about how much to validate:

| | on a malformed token | on a parent-base mismatch |
|---|---|---|
| `check_tree_sequences.compose()` | mis-slices silently | no check |
| `extract_root_sequence.apply_mutations()` | mis-slices silently | **warns, carries on** |
| `rebase_mat_root.root_sequence()` | — | fails hard |

That format has already produced one production bug (#49). Now one `utils.parse_mutation()` that raises rather than mis-slicing, and `apply_mutations()` adopts the strict policy — its warning has never fired in any log on disk, so this rejects nothing real, and `validate_sequences()` was already failing downstream on the *consequence* of the same problem.

`read_reference()` was also defined twice with different return types. One implementation now.

**Verified:** rebase reproduces all 16 `final_tree_root.fasta` byte-identically; the gate reproduces HA/H7's shipped report exactly; `extract_root_sequence` reproduces `curated_root.fasta` on 6 combinations.

## Delete `envs/larch.yaml`, drop config.yaml as a fake input (`a989917`)

**`envs/larch.yaml` was a trap, not a missing wire-up.** larch is built from source into the main env at **v0.1.3**; the packaged `larch-phylo` it referenced is only **0.1.0**. Adopting it would have silently downgraded the tree builder. Deleted, with the reason recorded so the two lint findings read as accepted rather than overlooked. `input_data_md5sums`, which had no such excuse, gets an env.

**config.yaml-as-input bought nothing.** Measured on a clean tree, changing one reroot target:

| trigger set | jobs re-run |
|---|---|
| default | **1235 of 1240** |
| `--rerun-triggers mtime` (params disabled) | **1235 of 1240** |

`download_all_references` passes config.yaml to its script — a real input at the head of the DAG — so any config edit cascades through the reference files to everything. Even `create_root_samples_file`, which never declared config.yaml, re-runs. The declarations were redundant under *every* trigger set, not just the default one, and left two patterns for the same lookup. Kept where genuinely read. At this point that still included `download_all_references`; commit `04f972e` below then removes it too, leaving only the two notebook rules, whose notebooks open the file directly.

CLAUDE.md's warning that `mtime` leaves config edits silently stale was wrong for the same reason. The real caveat is the opposite: config invalidation is maximally blunt, and any edit means a full re-derivation.

## Report every differing site; document the newick dialect; test three gaps (`26d5950`)

**The gate's failure diagnostic dropped sites.** `sorted(set(a) ^ set(b)) or ...` ran the value-mismatch scan only when the key-set difference was empty. For a sample differing at position 1 (called in both, G vs C) *and* position 3 (present in one tree only), it reported `[3]` and stayed silent about `1` — pointing whoever debugs it at the wrong site. Pass/fail was always correct. The new test discriminates: it fails against the old expression.

**The hand-rolled newick scans are documented rather than guarded,** because the property they need is already enforced: `sanitize_id()` strips `[ ] ( ) : ; , ' .` from every sequence ID, and `curate_and_extract_coding_seqs.py` applies it upstream of everything that becomes a leaf. Checked against the shipped trees: **0 of 84,664 labels** in HA/H7 and NA/N1 contain any of them. So the next reader gets a guarantee with a citation, not an assumption.

**Three untested error branches now covered:** a MAT with no node mutation lists (`rebase_onto_root` raises `ValueError` rather than an `IndexError` that said nothing about the cause), MSA samples missing from metadata, and the `ha`/`na` subtype-unparseable skip counters.

## Make config invalidation precise (`04f972e`)

The follow-on to the above: removing the *fake* config inputs did not shrink the blast radius, because `download_all_references` had a **real** one and sits at the head of the DAG. Editing any key it does not read — a reroot target, a seed, a threshold — changed the file's mtime, re-downloaded every reference, and cascaded through the whole pipeline.

Declared the four values the script actually consumes (`references`, `ha_subtypes`, `na_subtypes`, `segments` — verified to be all of them) as `params` instead. Confirmed on an isolated two-rule workflow:

| edit | config.yaml as input | used values as params |
|---|---|---|
| unrelated key | **re-runs** → cascades | **skipped** |
| used accession | re-runs | **re-runs** |

The script is unchanged. The difference from the pattern removed above: that one named the *file*, this names the *values*.

**Trade-off, now documented:** under `--rerun-triggers mtime` with the params trigger off, a config edit invalidates nothing at all. CLAUDE.md asserted the opposite, for a reason this change removes; corrected.

## Checks

| | |
|---|---|
| Tests | **202** pass (was 179), 8 ete3-gated |
| `snakemake --lint` | 8 findings (3 file-level + 5 rule-level); 9 on `main` -- this PR removes one |
| Dry run | DAG resolves |
| Real-data reproduction | 16/16 rebase, 6/6 root FASTA, gate report identical |

## Left in #51

- `rebase_mat_root.py`'s file-level round trip (`load_mat`/`save_mat`, `condensed_nodes`/`metadata` survival) — needs a second test invocation under `envs/taxonium`
- The gate's first-pass hash comparison, and `uncalled_positions` silently dropping samples absent from the VCF header
- No `resources:` declarations anywhere
- Packaging larch properly, which has to be validated against the trees it produces


