### PR TITLE
Seed each randomization's tree search with a time-stratified scaffold (closes #53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Flu-UShER Pipeline - A Snakemake pipeline for building phylogenetic trees of influenza virus sequences using UShER. The pipeline processes influenza sequences by segment and subtype, organizing HA and NA segments by their specific subtypes (e.g., H1, H3, N1, N2) while combining all subtypes for internal segments (PB2, PB1, PA, NP, MP, NS).
 
+Design rationale — why the pipeline is built the way it is, with the measurements
+behind each decision — lives in the "Design Notes" section of `README.md`. The
+Snakefile's own comments say only what each rule does and point there. Keep it
+that way: when you change a rule's reasoning, update `README.md`, not the
+Snakefile comment.
+
 ## Key Commands
 
 ### Environment Setup
@@ -61,10 +67,11 @@ snakemake --cores 8 --use-conda <target> --forcerun <rule_name>
 # re-runs the reroot rules and leaves the alignments alone. It did not used to
 # be -- download_all_references took config.yaml as an input at the head of the
 # DAG, so any edit re-downloaded the references and cascaded through
-# everything. Measured before that change: one reroot target re-ran 1235 of the
-# DAG's 1240 jobs, identically with and without the params trigger. (The five
-# spared are parse_gisaid_data, augment_metadata, the two annotation rules and
-# input_data_md5sums -- everything expensive re-derived.)
+# everything. Measured before that change, on the 1240-job DAG of the time: one
+# reroot target re-ran 1235 of 1240 jobs, identically with and without the
+# params trigger. (The five spared were parse_gisaid_data, augment_metadata, the
+# two annotation rules and input_data_md5sums -- everything expensive
+# re-derived.) The DAG is 1346 jobs since the scaffold rules were added.
 snakemake -n --use-conda <target> --rerun-triggers mtime
 
 # Generate workflow visualization
@@ -93,6 +100,9 @@ results/
 │   │   ├── randomized_{0,1,2,...}/  # Multiple randomizations
 │   │   │   ├── msa.fasta.xz
 │   │   │   ├── msa.vcf
+│   │   │   ├── scaffold_msa.fasta.xz            # time-spread subset
+│   │   │   ├── scaffold_samples.txt             # ids drawn into it
+│   │   │   ├── scaffold_tree.pb.gz              # backbone the full placement seeds from
 │   │   │   ├── preopt_tree.pb.gz
 │   │   │   ├── opt_tree.pb.gz
 │   │   │   └── dag.pb
@@ -141,6 +151,8 @@ results/
    - Reference sequences for each segment-subtype
    - Quality filtering thresholds (max_frac_gaps, max_frac_ambig)
    - Number of randomizations for tree building (n_randomizations)
+   - Number of taxa drawn into each randomization's scaffold tree (scaffold_n_taxa)
+   - Seed for sampling a tree out of the trimmed DAG (tree_sample_seed)
    - Number of threads for parallel execution
    - Geographic groups to extract for geographic subtree analysis (geographic_groups_to_extract)
    - Optional rerooting specifications for final trees (reroot)
@@ -150,6 +162,7 @@ results/
    - `download_ref_seq.py`: Downloads reference sequences from NCBI and creates Nextclade datasets
    - `curate_and_extract_coding_seqs.py`: Curates alignments by quality metrics, extracts coding regions and per-gene unaligned coding sequences
    - `randomize_alignment.py`: Creates randomized versions of alignments for multiple tree builds
+   - `create_scaffold_alignment.py`: Subsets an alignment to `scaffold_n_taxa` sequences spread evenly over collection year, for the backbone tree each randomization is seeded with
    - `trim_dag.py`: Trims suboptimal trees from merged DAGs
    - `convert_DAG_protobuf_to_newick_samples.py`: Samples representative trees from DAGs
    - `reroot_newick.py`: Reroots a newick at a named leaf via ete3 `set_outgroup`; validates the target exists, is unique, is a leaf, and ends up at the root
@@ -163,7 +176,7 @@ results/
    - `prepare_host_annotation.py`: Builds the global 2-column (isolate_id, host_group) CSV consumed by PastML
    - `prepare_subtype_annotation.py`: Builds the global 2-column (isolate_id, subtype) CSV consumed by PastML, normalizing the raw GISAID `subtype` ("A / H5N1") to `H*N*` form inline
    - `utils.py`: Shared helpers imported by the above — `open_sequence_file()` for plain/gz/xz IO, `setup_logging()`, `sanitize_id()`, and the GFF parsing used to derive coding coordinates
-   - `test_curate_and_extract_coding_seqs.py`, `test_parse_gisaid_data.py`, `test_create_samples_file.py`, `test_check_tree_sequences.py`, `test_reroot_newick.py`: unittest suites
+   - `test_*.py`: ten unittest suites, one per tested module (see Important Notes for counts)
 
 4. **notebooks/**: Jupyter notebooks for analysis and development
    - `analyze_alignments.ipynb`: Analyzes sequence statistics across segments/subtypes
@@ -178,17 +191,17 @@ results/
 5. **Create Unaligned Coding Sequences** → Extracts unaligned coding sequences from curated alignments
 6. **Randomize Alignments** → Creates multiple randomized versions of alignment (n_randomizations)
 7. **Create VCF** → Converts each randomized FASTA to variant format for UShER
-8. **Build Initial Trees** → Creates initial parsimony tree for each randomization with usher-sampled
+8. **Build Initial Trees** → Each randomization first draws a `scaffold_n_taxa` subset spread evenly over collection year (`create_scaffold_alignment`), builds and optimizes a backbone tree from it alone (`build_scaffold_tree`), then places every remaining sequence onto that backbone with usher-sampled (`create_initial_tree`, `-i` not `-t`). Placing all 86,232 HA/H3 sequences onto an *empty* tree instead settled on a measurably worse high-level shape — issue #53. Why the backbone exists, how the draw works, and the two measurement traps involved: see the "Design Notes" section of `README.md`.
 9. **Optimize Trees** → Refines topology for each tree with matOptimize
 10. **Convert to DAGs** → Converts each optimized tree to DAG representation (larch-usher)
 11. **Merge DAGs** → Combines all DAGs into single merged DAG (larch-dagutil)
 12. **Trim DAG** → Removes suboptimal trees from merged DAG
 13. **Sample Tree** → Samples a representative tree from trimmed DAG
 14. **Create MAT Protobuf** → Converts sampled tree to MAT protobuf format
-15. **Reroot Tree** → Where `reroot` is configured, reroots the *newick* at the named leaf with ete3 `set_outgroup` (`reroot_newick`), then rebuilds the MAT from the alignment with `usher` (`create_final_mat`), which keeps its mutations recorded against the reference. Combinations with no configured reroot symlink `reference_origin_tree.pb.gz` to `sampled_tree.pb.gz`; step 16 then runs on all 16 alike, so `final_tree.pb.gz` is always a real file and always means the same thing. Replaced `matUtils extract -y`, which moved the MAT's origin onto the new root and refused outright when the pre-reroot root carried a mutation (issue #49). `check_tree_sequences` then guards that the MAT is still recorded against the reference, and asserts the tree is rooted where config asked — the sequence comparison alone cannot tell, since both trees are built from the same VCF and so agree for any topology.
+15. **Reroot Tree** → Where `reroot` is configured, reroots the *newick* at the named leaf with ete3 `set_outgroup` (`reroot_newick`), then rebuilds the MAT from the alignment with `usher` (`create_final_mat`), which keeps its mutations recorded against the reference. Combinations with no configured reroot symlink `reference_origin_tree.pb.gz` to `sampled_tree.pb.gz`; step 16 then runs on all 16 alike, so `final_tree.pb.gz` is always a real file and always means the same thing. Replaced `matUtils extract -y` (issue #49). `check_tree_sequences` then guards that the MAT is still recorded against the reference, and asserts the tree is rooted where config asked. See "Rerooting" and "The sequence-identity gate" in the Design Notes of `README.md`.
 
-    Both MAT-building rules (`create_mat_protobuf`, `create_final_mat`) use `usher`, not `matOptimize`. These steps annotate a fixed topology; they do not search for a better one. `matOptimize` is a parsimony optimiser, and parsimony is an *unrooted* criterion, so it normalises the tree at load even under `-N 0` and does not preserve the input rooting. That silently broke NA/N1: its reroot target `EPI_ISL_5878` is the only one of the 14 whose terminal branch carries no mutations (the others run 6–87 in `sampled_tree.pb.gz`, 5–62 after rerooting), and it was the only one that lost its rooting. Empirically the rooting survives `matOptimize` only when the target's terminal branch carries mutations; the exact normalisation step responsible has not been traced to matOptimize's source, and the observed failure is not a simple collapse — NA/N1's root landed 54 mutations away under a 3-way polytomy, 56 substitutions from the intended root sequence, not merged into its neighbour. Switching both rules to `usher` fixed it and moved `curated_root.fasta` by one position in 2 of 16 combinations. `matOptimize` remains correct for `optimize_tree`, which really is topology optimisation.
-16. **Rebase MAT onto its Root** → `rebase_final_mat` moves the tree's origin from `curated_reference.fasta` onto the tree's own root, so the root carries no mutations and its sequence ships as `final_tree_root.fasta`. Reconstructing a sample from `final_tree.pb.gz` therefore starts from that file, not from the curated reference. This is pure bookkeeping: every branch below the root already records a parent-to-child change and is unaffected, so only the root's own mutation list (emptied) and each mutation's `ref_nuc` annotation (repointed) change. It is the same operation `matUtils extract -y` performed, minus its two defects — refusing whenever the root carried mutations, and discarding the root sequence instead of emitting it, which is what made the shift silent in issue #49.
+    Both MAT-building rules (`create_mat_protobuf`, `create_final_mat`) use `usher`, not `matOptimize`, because they annotate a fixed topology and must keep it, rooting included. `matOptimize` remains correct for `optimize_tree`, which really is topology optimisation. Why, and the NA/N1 failure that established it: see "Why `usher` and not `matOptimize`" in the Design Notes of `README.md`.
+16. **Rebase MAT onto its Root** → `rebase_final_mat` moves the tree's origin from `curated_reference.fasta` onto the tree's own root, so the root carries no mutations and its sequence ships as `final_tree_root.fasta`. Reconstructing a sample from `final_tree.pb.gz` therefore starts from that file, not from the curated reference. This is pure bookkeeping: only the root's own mutation list (emptied) and each mutation's `ref_nuc` annotation (repointed) change. It is the same operation `matUtils extract -y` performed, minus its two defects — see "Rerooting" in the Design Notes of `README.md`.
 17. **Create Root Sequence** → Infers root sequence from tree or uses reference
 18. **Augment Metadata** → Adds host_group, geographic_group, and temporal_group columns
 19. **Extract Subtrees** → Creates subtrees for each configured geographic region (matUtils extract)
@@ -207,7 +220,7 @@ The pipeline expects GISAID data in each input directory:
 
 ### Important Notes
 
-- Tests live in nine `scripts/test_*.py` modules (221 unittest tests: curate 91, check_tree_sequences 31, rebase_mat_root 30, utils 21, parse_gisaid 15, extract_root_sequence 13, create_samples 9, reroot_newick 8, config_params_sync 3). Run them with `python -m unittest discover` from within `scripts/`. Under `envs/python.yaml` that reports `OK (skipped=8)`: `test_reroot_newick.py` is `skipIf`-guarded because ete3 lives in its own env, so run it separately under `envs/ete3.yaml` to actually exercise those 8 — `OK (skipped=N)` otherwise reads like a pass. No linting setup currently exists, and 9 of the 17 script modules are untested.
+- Tests live in ten `scripts/test_*.py` modules (257 unittest tests: curate 91, create_scaffold_alignment 36, check_tree_sequences 31, rebase_mat_root 30, utils 21, parse_gisaid 15, extract_root_sequence 13, create_samples 9, reroot_newick 8, config_params_sync 3). Run them with `python -m unittest discover` from within `scripts/`. Under `envs/python.yaml` that reports `OK (skipped=8)`: `test_reroot_newick.py` is `skipIf`-guarded because ete3 lives in its own env, so run it separately under `envs/ete3.yaml` to actually exercise those 8 — `OK (skipped=N)` otherwise reads like a pass. No linting setup currently exists, and 9 of the 18 script modules are untested (augment_metadata, convert_DAG_protobuf_to_newick_samples, create_root_samples_file, download_ref_seq, prepare_host_annotation, prepare_subtype_annotation, randomize_alignment, simplified_host_classifier, trim_dag).
 - The pipeline uses compressed outputs (.xz, .gz) to save disk space
 - All logs are saved in the `logs/` directory organized by segment/subtype
 - The pipeline can process multiple influenza subtypes simultaneously

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ flu-usher/
 │   ├── download_ref_seq.py                         # Download reference sequences
 │   ├── curate_and_extract_coding_seqs.py           # Curate alignments and extract coding sequences
 │   ├── randomize_alignment.py                      # Randomize alignment order
+│   ├── create_scaffold_alignment.py                # Subset an alignment to a time-spread sample
 │   ├── trim_dag.py                                 # Trim suboptimal trees from DAG
 │   ├── convert_DAG_protobuf_to_newick_samples.py   # Sample tree from DAG
 │   ├── create_root_samples_file.py                 # Create samples file for root extraction
@@ -118,6 +119,9 @@ flu-usher/
    - `randomized_{n}/`: Directory for each randomized alignment (n = 0, 1, 2, ...)
      - `msa.fasta.xz`: Randomized alignment
      - `msa.vcf`: Variant call format file
+     - `scaffold_msa.fasta.xz`: Time-spread subset of the alignment (see [Design Notes](#design-notes))
+     - `scaffold_samples.txt`: Ids that went into the scaffold, one per line
+     - `scaffold_tree.pb.gz`: Optimized backbone tree built from that subset
      - `preopt_tree.pb.gz`: Initial parsimony tree
      - `opt_tree.pb.gz`: Optimized tree
      - `dag.pb`: DAG representation of the tree
@@ -185,9 +189,11 @@ flu-usher/
    - Converts each randomized FASTA alignment to variant format
    - Includes reference and handles ambiguous nucleotides
 
-7. **Build initial tree** (usher-sampled):
-   - Creates parsimony-based phylogenetic tree for each randomization
-   - Uses empty starting tree and builds incrementally
+7. **Build initial tree** (`create_scaffold_alignment.py`, faToVcf, usher-sampled, matOptimize):
+   - Draws `scaffold_n_taxa` sequences spread evenly across collection year into a scaffold alignment
+   - Builds and optimizes a backbone tree from that subset alone
+   - Places every remaining sequence onto the backbone with usher-sampled
+   - Why the backbone exists, and how the draw works: see [Design Notes](#design-notes)
 
 8. **Optimize tree** (matOptimize):
    - Refines tree topology to minimize parsimony score for each randomization
@@ -209,13 +215,15 @@ flu-usher/
     - Samples a representative tree from the trimmed DAG
     - Outputs in Newick format
 
-13. **Create MAT protobuf** (matOptimize):
+13. **Create MAT protobuf** (usher):
     - Converts the sampled Newick tree to MAT protobuf format
     - Required for downstream matUtils operations
 
-14. **Reroot tree** (matUtils extract):
-    - Reroots the tree at a specified node if configured
-    - Otherwise creates a symlink to the sampled tree
+14. **Reroot tree** (`reroot_newick.py`, usher, `rebase_mat_root.py`, `check_tree_sequences.py`):
+    - Where `reroot` is configured, reroots the *newick* at the named leaf, then rebuilds the MAT from the alignment; other combinations symlink the sampled MAT through unchanged
+    - Moves the MAT's origin from the reference onto the tree's own root, writing that root out as `final_tree_root.fasta`
+    - Checks that no sample's sequence changed across rerooting and that the tree is rooted where the config asked, writing `reroot_sequence_check.txt`
+    - Why rerooting happens in newick space rather than with `matUtils extract -y`: see [Design Notes](#design-notes)
 
 15. **Create root sequence** (`extract_root_sequence.py` or symlink):
     - If rerooted: Infers root sequence from tree mutations
@@ -256,6 +264,210 @@ flu-usher/
 22. **Record input data md5 sums** (md5sum):
     - Walks every `.fasta` and `.xls` file under the configured `input_dirs` and writes their md5 hashes to `results/input_data_md5sums.txt` as a provenance manifest
     - Files are listed as explicit Snakemake inputs, so the manifest is regenerated whenever any input data file changes
+
+## Design Notes
+
+Why the pipeline is built the way it is. The Snakefile carries only short
+comments saying what each rule does; the reasoning lives here, so that these
+notes can be read as a whole and can carry evidence at length.
+
+### Why each tree search starts from a time-spread scaffold
+
+Issue #53. Placing all 86,232 HA/H3 sequences onto an empty tree settled on a
+high-level shape that is measurably not the most parsimonious one available:
+sequences collected from 2006 on sat ~70 branches deeper on the trunk than
+2005's, with no matching rise in divergence. Building a ~1000-sequence backbone
+first and placing everything else onto it fixed that *and* improved the score,
+which is what says the search rather than the data was at fault. On the same
+86,232 sequences, HA/H3's `final_tree` went from 185,398 to 185,301 parsimony
+and 2006's median depth from 161 to 93.
+
+The clearest evidence is per-randomization rather than on the merged result.
+Rerooted and measured by cohort, 4 of the 10 baseline `opt_tree`s had 2006
+sitting 18-28 branches *deeper* than 2013; with a scaffold, 0 of 10 do, and 9 of
+10 are clean at 2/2571 leaves inverted. So the per-randomization search was
+itself part of the problem — an earlier write-up claimed the search was never at
+fault, which was wrong, and rested on the two randomizations that happened to be
+clean.
+
+Two measurement traps, both of which earlier write-ups fell into:
+
+- **Do not compare a scaffolded subset against the same leaves extracted from a
+  full tree.** Restricting an 86k-leaf tree to 1k leaves inflates its parsimony
+  there, because a globally optimal tree does not induce an optimal subtree. The
+  scaffolded tree is globally better (185,301 vs 185,398) and still scores 8365
+  on such a subset against a de novo 8298.
+- **Do not quote the share of pre-2009 leaves deeper than the median 2013 leaf
+  on its own.** It reads 35% for the pathological baseline tree while the
+  aggregate median gap simultaneously reads -46, because pre-2009 is dominated
+  by shallow pre-2005 leaves. Use the 2006 / 2007 cohort medians.
+
+### How the scaffold is sampled
+
+Quotas are per collection *year*, not per sequence: HA/H3 has eight sequences
+from 1963 and 11,786 from 2024, and a plain random draw of 1000 would take ~150
+from 2024 alone and miss most years before 1991 entirely. Years that cannot fill
+their share hand the remainder back to be redistributed — repeatedly, since a
+redistribution can itself overfill a small year. Sequences with no collection
+date are not candidates, since they carry no information about where on the time
+axis they belong; they are placed later, in the pass that adds every
+non-scaffold sequence, so nothing is dropped.
+
+Each draw uses that randomization's seed, so the backbones differ: on HA/H3 any
+two share only ~26% of their ids, which is what lets the merged DAG keep
+exploring topology space. Note the draw depends on the seed alone and *not* on
+the alignment's order — the sort in `select_scaffold_ids` is deliberate — so the
+shuffle decides only the order the chosen records are written in. On small
+combinations the backbones are necessarily much more alike: NA/N9 draws 1000 of
+just 1827 dated sequences, and any two of its scaffolds share ~72%.
+
+`create_scaffold_alignment` reads `combined_metadata.csv` rather than the
+augmented file. It needs only `collection_date`, and depending on the augmented
+file would put host and geography classification upstream of every tree in the
+pipeline.
+
+`scaffold.vcf` is `temp()` while the full `msa.vcf` is not: it has a single
+consumer, and faToVcf regenerates it in seconds from the scaffold alignment,
+which is kept precisely so that it can.
+
+`build_scaffold_tree` runs usher-sampled and matOptimize in one rule, because
+both take seconds at this size and there is nothing to gain from a checkpoint
+between them. Their full-size equivalents (`create_initial_tree`,
+`optimize_tree`) stay separate because they are the two most expensive steps in
+the pipeline.
+
+`create_initial_tree` takes the scaffold as a MAT (`-i`) rather than as a newick
+(`-t`), because `matUtils extract -t` segfaults in this usher build even on a
+~1600-node tree (reproduced, core dumped), so the routine way of handing the
+optimized scaffold over as a newick is unavailable. Feeding the MAT straight
+through costs nothing either way, since usher re-derives the backbone's states
+from the full VCF. Samples already in the scaffold are skipped rather than
+duplicated: HA/H3's `preopt_tree` holds exactly 86,232 samples and
+`placement_stats.tsv` has 85,231 rows, i.e. 86,232 - 1,001.
+
+### Rerooting: newick space, not `matUtils extract -y`
+
+Issue #49. `matUtils extract -y` rebases the MAT into the new root's coordinate
+frame: the new root is written with zero mutations, so the file stops recording
+how it differs from the reference. That is self-consistent and readable if you
+know the new root's sequence, but it refuses outright when the existing root
+carries a mutation (which broke HA/H3), and the frame shift is implicit —
+nothing records it. Rerooting the topology in newick space instead leaves
+mutation assignment to the MAT-building rule, which reads it off the alignment
+and so keeps the MAT in the reference's frame.
+
+`rebase_final_mat` then performs that frame shift deliberately, for all 16
+combinations alike so that `final_tree.pb.gz` means the same thing everywhere.
+It is pure bookkeeping: every branch below the root already records a
+parent-to-child change independent of what the origin is, so only the root's own
+mutation list (emptied) and each mutation's `ref_nuc` annotation (repointed)
+change. Unlike `-y`, it does not refuse when the root carries mutations, and it
+emits the root sequence rather than discarding it — that discard is what made
+the shift silent in #49.
+
+### Why `usher` and not `matOptimize` builds the final MATs
+
+Both `create_mat_protobuf` and `create_final_mat` annotate a *fixed* topology;
+they do not search for a better one. `matOptimize` is a parsimony optimizer, and
+parsimony is an *unrooted* criterion, so it normalizes the tree at load —
+collapsing zero-mutation branches — even under `-N 0`, and does not preserve the
+input rooting.
+
+That silently broke NA/N1. Its reroot target `EPI_ISL_5878` is the only one of
+the 14 whose terminal branch carries no mutations (the others run 6-87 in
+`sampled_tree.pb.gz`, 5-62 after rerooting), and it was the only one that lost
+its rooting: the root landed 54 mutations away under a 3-way polytomy, 56
+substitutions from the intended root sequence — not a simple collapse into its
+neighbour. Empirically the rooting survives `matOptimize` only where the
+target's terminal branch carries mutations; the exact normalization step
+responsible has not been traced to matOptimize's source. Switching both rules to
+`usher`, which takes the topology as authoritative, fixed it and moved
+`curated_root.fasta` by one position in 2 of 16 combinations. `matOptimize`
+remains correct for `optimize_tree`, which really is topology optimization.
+
+### The sequence-identity gate
+
+`check_tree_sequences` is a standing guard against the class of bug in #49:
+rerooting is a pure re-representation, so every sequence the tree implies must
+survive it unchanged. It runs for every combination, including the two that are
+not rerooted, where it is a cheap tautology.
+
+It also asserts that the tree is rooted where the config asked, because the
+sequence comparison alone cannot tell: both trees are built from the same VCF
+and so agree for any topology.
+
+Everything derived from the final tree — the Taxonium conversions, the
+geographic subtrees, `final_tree.nwk` and the two PastML rules that read it —
+depends on the gate's report rather than merely being listed alongside it in
+`rule all`. That dependency is what makes it a gate. Building one combination by
+targeting its `final_tree.jsonl.gz` produces a DAG that never reaches `rule
+all`, so without those edges the check would be skipped for exactly the workflow
+people use most and a bad tree would be published anyway.
+
+### larch is built from source, not installed from conda
+
+`tree_to_dag` and `larch_merge` have no `conda:` directive, and `snakemake
+--lint` flags both for it. That is accepted, not an oversight: larch is built
+from source into the main flu-usher environment (`environment.yml` carries its
+build and runtime deps, not larch itself), from commit `0ac4146`, built
+2025-10-27.
+
+`envs/larch.yaml` used to point at the packaged `larch-phylo`, and was deleted
+rather than wired up. The package's "0.1.0" version string is a stale
+VERSION-file fallback — conda-build strips `.git`, so its `git describe` never
+runs — not a lower release: it is built from `c2e75a2`, which is the `v0.1.3`
+tag. The real gap is the 5 commits from there to `0ac4146`, and adopting it
+would not have degraded anything quietly, it would have broken outright:
+`fb1bb78` is what added VCF support to `larch-dagutil`, so the packaged binary
+has no `-v` option and `larch_merge` passes one. It also pins `python_abi` 3.8
+and `boost-cpp` 1.76. Packaging larch properly is a separate change that has to
+be validated against the trees it produces.
+
+### Snakemake bookkeeping
+
+**`script_deps`.** Only rules using Snakemake's `script:` directive are
+code-tracked. The scripts invoked as `shell: python scripts/x.py` appear in no
+`input:` block, so editing one leaves Snakemake reporting every downstream
+output up to date. Declaring them as inputs closes that gap. Every script
+imports `utils`, so it is always included.
+
+**Config invalidation.** `download_all_references` deliberately does *not* take
+`config.yaml` as an input. It sits at the head of the DAG, so depending on the
+file's mtime made every config edit — a reroot target, a seed, a filtering
+threshold — re-download the references and re-derive the whole pipeline;
+measured before the change, one altered reroot target re-ran 1235 of 1235 jobs.
+Naming the consumed values in `params:` instead keeps the default `params`
+rerun-trigger precise, and the script still reads the file for the rest.
+
+**Wildcard constraints.** Without them the default wildcard regex is `.+`, which
+matches `/`. A typo in a target path then resolves against the wrong rule with a
+wildcard spanning directory separators, instead of failing.
+
+**Empty input list.** `input_data_md5sums` fails at parse time when no GISAID
+input files are found, rather than degrading silently. With an empty list,
+`md5sum {input} > {output}` becomes a bare `md5sum` reading stdin, which writes
+`d41d8cd98f00b204e9800998ecf8427e  -` and exits 0 — a provenance manifest
+recording nothing. `set -euo pipefail` would not catch it, because
+zero-argument `md5sum` succeeds.
+
+**Thread declarations.** usher detects hardware concurrency when `-T` is
+omitted, so a rule that did not declare `threads` claimed 1 core from the
+scheduler and then spawned 32. Both MAT-building rules declare it and pass it
+through.
+
+**Private scratch directories.** `usher` and `usher-sampled` write
+`final-tree.nh` and other fixed-name files beside their `-d` target, so rules
+that would otherwise share a directory each get a `mktemp -d`. `matUtils`
+prepends `-d` to the `-S` path even when it is absolute and then silently writes
+nothing, which is why `-S` must stay a bare filename.
+
+**One rule per notebook.** The notebooks produce figures unevenly —
+`analyze_alignments` 3, `analyze_dags` 1, `analyze_metadata` 0 — so a single
+`{notebook}` wildcard rule cannot declare them, because an output list cannot
+depend on a wildcard value. Each writes its executed copy under `results/`
+instead of running `--inplace` over the git-tracked source, which rewrote
+tracked files and churned output-cell diffs on every run while declaring only a
+`.done` sentinel.
 
 ## Requirements
 

--- a/Snakefile
+++ b/Snakefile
@@ -2,9 +2,8 @@
 import glob
 configfile: "config.yaml"
 
-# Without these the default wildcard regex is `.+`, which matches `/`. A typo in
-# a target path then resolves against the wrong rule with a wildcard spanning
-# directory separators instead of failing.
+# Narrow the default `.+` wildcard regex so that no wildcard spans a directory
+# separator. See "Snakemake bookkeeping" in README.md.
 wildcard_constraints:
     segment="[A-Za-z0-9]+",
     subtype="[A-Za-z0-9]+",
@@ -13,11 +12,8 @@ wildcard_constraints:
 
 
 
-# Only rules using Snakemake's `script:` directive are code-tracked. The ten
-# scripts invoked as `shell: python scripts/x.py` appear in no input: block, so
-# editing one leaves Snakemake reporting every downstream output up to date.
-# Declaring them as inputs closes that gap. Every script imports utils, so it is
-# always included.
+# Declare shell-invoked scripts as rule inputs so that editing one invalidates
+# its downstream outputs. See "Snakemake bookkeeping" in README.md.
 def script_deps(*script_names, include_utils=True):
     """Input paths for a shell-invoked script plus the modules it imports."""
     deps = ["scripts/" + name for name in script_names]
@@ -25,19 +21,15 @@ def script_deps(*script_names, include_utils=True):
 
 
 # Discover every GISAID FASTA + XLS file across the configured input dirs at
-# parse time so the md5 manifest rule can list them as explicit inputs and be
-# reinvalidated whenever any of them change.
+# parse time, so that input_data_md5sums can list them as explicit inputs.
 INPUT_DATA_FILES = sorted(
     f
     for d in config["input_dirs"]
     for f in glob.glob(f"{d}/*.fasta") + glob.glob(f"{d}/*.xls")
 )
 
-# Fail at parse time rather than let input_data_md5sums degrade silently. With an
-# empty list, `md5sum {input} > {output}` becomes a bare `md5sum` reading stdin,
-# which writes "d41d8cd98f00b204e9800998ecf8427e  -" and exits 0 -- a provenance
-# manifest recording nothing. `set -euo pipefail` would not catch it, because
-# zero-argument md5sum succeeds.
+# Fail at parse time rather than let input_data_md5sums silently hash stdin and
+# exit 0. See "Snakemake bookkeeping" in README.md.
 if not INPUT_DATA_FILES:
     raise WorkflowError(
         "No GISAID input files found. Looked for *.fasta and *.xls under: "
@@ -182,14 +174,9 @@ rule download_all_references:
     input:
         script=script_deps("download_ref_seq.py")
     params:
-        # The values this rule actually consumes, declared so the default
-        # `params` rerun-trigger hashes them. config.yaml is deliberately NOT an
-        # input: this rule sits at the head of the DAG, so depending on the
-        # file's mtime made every config edit -- a reroot target, a seed, a
-        # filtering threshold -- re-download the references and re-derive the
-        # whole pipeline. Measured before this change: one reroot target
-        # changed re-ran 1235 of 1235 jobs. Naming the values instead keeps the
-        # trigger precise; the script still reads the file for the rest.
+        # The values this rule consumes, declared so the default `params`
+        # rerun-trigger hashes them. config.yaml is deliberately NOT an input --
+        # see "Config invalidation" in README.md.
         references=config["references"],
         ha_subtypes=config["ha_subtypes"],
         na_subtypes=config["na_subtypes"],
@@ -313,50 +300,17 @@ rule create_vcf:
         | faToVcf -includeRef -ambiguousToN -includeNoAltN stdin {output} 2> {log}
         """
 
-# Build a time-spread backbone before placing the full alignment (issue #53).
-#
-# Placing all 86,232 HA/H3 sequences onto an empty tree settled on a high-level
-# shape that is measurably not the most parsimonious one available: sequences
-# collected from 2006 on sat ~70 branches deeper on the trunk than 2005's, with
-# no matching rise in divergence. Scaffolding fixed that and improved the score
-# at the same time, which is what says the search rather than the data was at
-# fault. On the same 86,232 sequences, HA/H3's final_tree went from 185,398 to
-# 185,301 parsimony and 2006's median depth from 161 to 93.
-#
-# The clearest evidence is per-randomization, not on the merged result. Rerooted
-# and measured by cohort, 4 of the 10 baseline opt_trees had 2006 sitting 18-28
-# branches *deeper* than 2013; with a scaffold, 0 of 10 do, and 9 of 10 are clean
-# at 2/2571. So the search itself was part of the problem -- an earlier version of
-# this comment claimed the search was never at fault, which was wrong, and rested
-# on the two randomizations that happened to be clean.
-#
-# Two measurement traps, both of which earlier versions of this comment fell into.
-# Do not compare a scaffolded subset against the same leaves extracted from a full
-# tree: restricting an 86k-leaf tree to 1k leaves inflates its parsimony there,
-# because a globally optimal tree does not induce an optimal subtree. The
-# scaffolded tree is globally better (185,301 vs 185,398) and still scores 8365 on
-# such a subset against a de novo 8298. And do not quote the share of pre-2009
-# leaves deeper than the median 2013 leaf on its own: it reads 35% for the
-# pathological baseline tree and -46 on the aggregate median gap at the same time,
-# because pre-2009 is dominated by shallow pre-2005 leaves. Use the 2006/2007
-# cohort medians.
-#
-# Optimising ~1000 sequences is a far easier search than optimising 86,232, so
-# each randomization builds its own backbone from a time-spread subset first.
-# Each draw uses that randomization's seed, so the backbones differ: on HA/H3 any
-# two share only ~26% of their ids, which is what lets the merged DAG keep
-# exploring topology space. Note the draw depends on the seed alone and not on the
-# alignment's order -- the sort in select_scaffold_ids is deliberate -- so the
-# shuffle decides only the order the chosen records are written in. On small
-# combinations the backbones are necessarily much more alike (NA/N9 draws 1000 of
-# just 1827 dated sequences, and any two of its scaffolds share ~72%).
+# Draw scaffold_n_taxa sequences spread evenly over collection year, to be built
+# into a backbone tree before the full alignment is placed (issue #53). Each
+# randomization draws with its own seed, so the backbones differ. Why the backbone
+# exists and how the draw works: see "Why each tree search starts from a
+# time-spread scaffold" in README.md.
 rule create_scaffold_alignment:
     conda: "envs/python.yaml"
     input:
         msa="results/{segment}/{subtype}/randomized_{n}/msa.fasta.xz",
-        # combined_metadata.csv, not the augmented one: this needs only
-        # collection_date, and depending on the augmented file would put host
-        # and geography classification upstream of every tree in the pipeline.
+        # combined_metadata.csv, not the augmented one: only collection_date is
+        # needed here.
         metadata="results/combined_metadata.csv",
         script=script_deps("create_scaffold_alignment.py")
     output:
@@ -386,9 +340,8 @@ rule create_scaffold_vcf:
     input:
         msa="results/{segment}/{subtype}/randomized_{n}/scaffold_msa.fasta.xz"
     output:
-        # temp(), unlike the full msa.vcf, which half a dozen later rules read:
-        # this one has a single consumer and faToVcf regenerates it in seconds
-        # from the scaffold alignment, which is kept precisely so that it can.
+        # temp(), unlike the full msa.vcf: single consumer, and regenerated in
+        # seconds from the scaffold alignment.
         temp("results/{segment}/{subtype}/randomized_{n}/scaffold.vcf")
     log:
         "logs/{segment}/{subtype}/randomized_{n}/create_scaffold_vcf.log"
@@ -398,10 +351,9 @@ rule create_scaffold_vcf:
         | faToVcf -includeRef -ambiguousToN -includeNoAltN stdin {output} 2> {log}
         """
 
-# usher-sampled then matOptimize on the scaffold, in one rule: both run in
-# seconds at this size, so there is nothing to gain from a checkpoint between
-# them. This mirrors create_initial_tree + optimize_tree, which stay separate
-# because at full size they are the two most expensive steps in the pipeline.
+# Build and optimize the backbone tree from the scaffold alignment alone.
+# usher-sampled and matOptimize share one rule here because both run in seconds
+# at this size; their full-size equivalents stay separate.
 rule build_scaffold_tree:
     conda: "envs/usher.yaml"
     input:
@@ -412,11 +364,10 @@ rule build_scaffold_tree:
     log:
         "logs/{segment}/{subtype}/randomized_{n}/build_scaffold_tree.log"
     shell:
-        # A private scratch dir, because usher-sampled writes final-tree.nh and
-        # several other fixed-name files beside its -d target -- which would
-        # collide with create_initial_tree writing into the same randomization
-        # directory. -n on matOptimize suppresses intermediate protobufs, which
-        # at this size are pure clutter: there is no long run to resume.
+        # A private scratch dir, because usher-sampled writes fixed-name files
+        # beside its -d target that would collide with create_initial_tree's.
+        # -n on matOptimize suppresses intermediate protobufs: at this size
+        # there is no long run to resume.
         """
         TMPD=$(mktemp -d)
         trap "rm -rf $TMPD" EXIT
@@ -451,18 +402,9 @@ rule create_initial_tree:
         stdout="logs/{segment}/{subtype}/randomized_{n}/usher-sampled.log",
         stderr="logs/{segment}/{subtype}/randomized_{n}/usher-sampled.stderr"
     shell:
-        # -i, not -t: matUtils extract -t segfaults in this usher build even on a
-        # ~1600-node tree (reproduced, core dumped), so the routine way of handing
-        # the optimised scaffold over as a newick is unavailable. Feeding the MAT
-        # straight through costs nothing either way, since usher re-derives the
-        # backbone's states from the full VCF. Samples already in the scaffold are
-        # skipped rather than duplicated: HA/H3's preopt_tree holds exactly 86,232
-        # samples and placement_stats.tsv has 85,231 rows, i.e. 86,232 - 1,001.
-        #
-        # A -i-versus-newick parsimony pair quoted here previously (189,532 against
-        # 189,536) is not reproducible from anything on disk and has been removed
-        # rather than restated; the newick side of it was obtained by dumping the
-        # MAT's newick field directly, not via matUtils extract -t.
+        # -i, not -t: the scaffold is handed over as a MAT rather than a newick,
+        # and samples already in it are skipped rather than duplicated. See
+        # "How the scaffold is sampled" in README.md.
         """
         usher-sampled -T {threads} -A \
             -i {input.scaffold} \
@@ -493,22 +435,11 @@ rule optimize_tree:
             &> {log}
         """
 
-# Convert optimized trees to DAGs
-# larch has no `conda:` directive, and snakemake --lint flags both rules for it.
+# Convert optimized trees to DAGs.
+# No `conda:` directive, and snakemake --lint flags both larch rules for it.
 # That is accepted, not an oversight: larch is built from source into the main
-# flu-usher environment (environment.yml carries its build and runtime deps,
-# not larch itself), from commit 0ac4146, built 2025-10-27.
-#
-# envs/larch.yaml used to sit here pointing at the packaged larch-phylo, and was
-# deleted rather than wired up. Note the package's "0.1.0" version string is a
-# stale VERSION-file fallback -- conda-build strips .git, so its `git describe`
-# never runs -- not a lower release: it is built from c2e75a2, which is the
-# v0.1.3 tag. The real gap is the 5 commits from there to 0ac4146, and adopting
-# it would not have degraded anything quietly, it would have broken outright:
-# fb1bb78 is what added VCF support to larch-dagutil, so the packaged binary has
-# no -v option and larch_merge below passes one. It also pins python_abi 3.8 and
-# boost-cpp 1.76. Packaging larch properly is a separate change that has to be
-# validated against the trees it produces.
+# flu-usher environment, from commit 0ac4146, built 2025-10-27. See "larch is
+# built from source" in README.md.
 rule tree_to_dag:
     input:
         tree="results/{segment}/{subtype}/randomized_{n}/opt_tree.pb.gz",
@@ -599,21 +530,16 @@ rule create_mat_protobuf:
         vcf_file="results/{segment}/{subtype}/randomized_0/msa.vcf"
     output:
         protobuf_name="results/{segment}/{subtype}/sampled_tree.pb.gz"
-    # usher detects hardware concurrency when -T is omitted, so an undeclared
-    # rule claimed 1 core from the scheduler and then span 32. Declare and pass
-    # it through, as create_alignment and optimize_tree already do.
+    # usher grabs every core unless told otherwise; see "Thread declarations"
+    # in README.md.
     threads: config["threads"]
     log:
         "logs/{segment}/{subtype}/create_mat_protobuf.log"
     shell:
-        # usher, not matOptimize: this step annotates a fixed topology, it does
-        # not search for a better one. matOptimize is a parsimony optimiser, and
-        # parsimony is an unrooted criterion, so it normalises the tree at load
-        # -- collapsing zero-mutation branches -- even under -N 0. That discards
-        # the rooting, which broke NA/N1 (see create_final_mat). usher takes the
-        # topology as authoritative. -d gets a private scratch dir because usher
-        # writes final-tree.nh beside its output, which would otherwise collide
-        # with the other MAT rule writing into the same combination directory.
+        # usher, not matOptimize: this step annotates a fixed topology and must
+        # keep it, rooting included. See "Why usher and not matOptimize" in
+        # README.md. -d gets a private scratch dir because usher writes
+        # final-tree.nh beside its output.
         """
         TMPD=$(mktemp -d)
         trap "rm -rf $TMPD" EXIT
@@ -638,15 +564,10 @@ def final_mat_source(wildcards):
     return f"{base}/sampled_tree.pb.gz"
 
 
-# Reroot in newick space rather than with `matUtils extract -y`. That flag
-# rebases the MAT into the new root's coordinate frame: the new root is written
-# with zero mutations, so the file stops recording how it differs from the
-# reference. That is self-consistent and readable if you know the new root's
-# sequence, but it refuses outright when the existing root carries mutations
-# (which broke HA/H3), and the frame shift is implicit -- nothing records it.
-# See issue #49. Rerooting the topology here leaves mutation assignment to
-# matOptimize below, which reads it off the alignment, keeping the MAT in the
-# reference's frame.
+# Reroot the sampled newick at the configured leaf. Done in newick space rather
+# than with `matUtils extract -y`, so that mutation assignment is left to the
+# MAT-building rule below and the MAT stays in the reference's frame. See
+# "Rerooting" in README.md and issue #49.
 rule reroot_newick:
     conda: "envs/ete3.yaml"
     input:
@@ -684,13 +605,8 @@ rule create_final_mat:
         "logs/{segment}/{subtype}/create_final_mat.log"
     shell:
         # usher rather than matOptimize, because this step must preserve the
-        # rooting reroot_newick just established. matOptimize normalises the
-        # tree at load even with -N 0 and does not preserve the input rooting.
-        # Empirically it survives only where the reroot target's terminal branch
-        # carries mutations: NA/N1's EPI_ISL_5878 is the one target of 14 whose
-        # branch is 0 (the others run 6-87 here), and the one that lost its
-        # rooting -- its root landed 54 mutations away, 56 substitutions from
-        # the intended root sequence. usher keeps the topology as given.
+        # rooting reroot_newick just established. See "Why usher and not
+        # matOptimize" in README.md.
         """
         if [ -n "{params.new_root}" ]; then
             TMPD=$(mktemp -d)
@@ -705,11 +621,9 @@ rule create_final_mat:
 
 
 # Move the tree's origin from the reference onto its own root, so the root
-# carries no mutations and its sequence ships alongside. Pure bookkeeping: every
-# branch below the root already records a parent-to-child change, independent of
-# what the origin is, so only the root's own mutation list and the ref_nuc
-# annotations move. Applied to all 16 combinations, rerooted or not, so
-# final_tree.pb.gz means the same thing everywhere.
+# carries no mutations and its sequence ships alongside as final_tree_root.fasta.
+# Applied to all 16 combinations, rerooted or not, so final_tree.pb.gz means the
+# same thing everywhere. See "Rerooting" in README.md.
 rule rebase_final_mat:
     conda: "envs/taxonium.yaml"
     input:
@@ -735,10 +649,9 @@ rule rebase_final_mat:
         """
 
 
-# Standing guard against the class of bug in #49: rerooting is a pure
-# re-representation, so every sequence the tree implies must survive it
-# unchanged. Runs for every combination, including the two that are not
-# rerooted, where it is a cheap tautology.
+# Dump the per-sample mutation paths of the sampled and final trees, plus the
+# final newick, for the sequence-identity gate below. See "The sequence-identity
+# gate" in README.md.
 rule extract_tree_sequence_paths:
     conda: "envs/usher.yaml"
     input:
@@ -763,6 +676,9 @@ rule extract_tree_sequence_paths:
         """
 
 
+# Assert that no sample's sequence changed across rerooting, and that the final
+# tree is rooted where config asked. Runs for every combination, including the
+# ones that are not rerooted, where it is a cheap tautology.
 rule check_tree_sequences:
     conda: "envs/python.yaml"
     input:
@@ -894,11 +810,8 @@ rule convert_to_taxonium:
     conda: "envs/taxonium.yaml"
     input:
         final_tree="results/{segment}/{subtype}/final_tree.pb.gz",
-        # Depending on the gate's report, not just listing it in `rule all`, is
-        # what makes it a gate. CLAUDE.md documents building one combination by
-        # targeting its final_tree.jsonl.gz; that DAG never reaches `rule all`,
-        # so without this edge the check is skipped for exactly the workflow
-        # people use most, and a bad tree gets published anyway.
+        # Nothing derived from the final tree ships until the gate has passed.
+        # See "The sequence-identity gate" in README.md.
         check="results/{segment}/{subtype}/reroot_sequence_check.txt",
         metadata="results/combined_metadata_augmented.csv"
     output:
@@ -945,8 +858,7 @@ rule extract_geographic_subtree:
     conda: "envs/usher.yaml"
     input:
         tree="results/{segment}/{subtype}/final_tree.pb.gz",
-        # See convert_to_taxonium: nothing derived from the final tree ships
-        # until the gate has passed.
+        # See convert_to_taxonium.
         check="results/{segment}/{subtype}/reroot_sequence_check.txt",
         samples="results/{segment}/{subtype}/geographic_trees/{geo_group}_samples.txt"
     output:
@@ -1100,14 +1012,10 @@ ALL_FINAL_TREES = (
              segment=[s for s in config["segments"] if s not in ["HA", "NA"]])
 )
 
-# The notebooks produce figures unevenly -- analyze_alignments 3, analyze_dags 1,
-# analyze_metadata 0 -- so a single {notebook} wildcard rule cannot declare them:
-# an output list cannot depend on the wildcard value. Hence one rule per
-# notebook, sharing the input list above.
-#
-# Each writes its executed copy to results/ instead of running --inplace over the
-# git-tracked source, which rewrote tracked files and churned output-cell diffs
-# on every run while declaring only a .done sentinel.
+# One rule per notebook, sharing the input list above, because they produce
+# figures unevenly and an output list cannot depend on a wildcard value. Each
+# writes its executed copy to results/ rather than --inplace over the tracked
+# source. See "One rule per notebook" in README.md.
 
 rule execute_analyze_alignments:
     conda: "envs/python.yaml"

--- a/Snakefile
+++ b/Snakefile
@@ -315,27 +315,41 @@ rule create_vcf:
 
 # Build a time-spread backbone before placing the full alignment (issue #53).
 #
-# usher-sampled places sequences greedily in alignment order onto an empty tree,
-# and on HA/H3 that settled on a high-level shape which is measurably not the
-# most parsimonious one available: sequences collected from 2006 on sat ~70
-# branches deeper on the trunk than 2005's, with no matching rise in divergence,
-# and 35% of pre-2008 leaves sat deeper than the median 2013 leaf. Scaffolding
-# fixed both at once, which is what says the search rather than the data was at
-# fault: on the same 86,232 sequences, HA/H3's final_tree went from 185,398 to
-# 185,299 parsimony, 2006's median depth from 161 to 92, and that 35% to 0%.
+# Placing all 86,232 HA/H3 sequences onto an empty tree settled on a high-level
+# shape that is measurably not the most parsimonious one available: sequences
+# collected from 2006 on sat ~70 branches deeper on the trunk than 2005's, with
+# no matching rise in divergence. Scaffolding fixed that and improved the score
+# at the same time, which is what says the search rather than the data was at
+# fault. On the same 86,232 sequences, HA/H3's final_tree went from 185,398 to
+# 185,301 parsimony and 2006's median depth from 161 to 93.
 #
-# Do not compare a scaffolded subset against the same leaves extracted from a
-# full tree -- an earlier version of this comment did, and the comparison is
-# confounded. Restricting an 86k-leaf tree to a 1k-leaf subset inflates its
-# parsimony on that subset, because a globally optimal tree does not induce an
-# optimal subtree. Only whole-tree scores on a fixed sequence set compare.
+# The clearest evidence is per-randomization, not on the merged result. Rerooted
+# and measured by cohort, 4 of the 10 baseline opt_trees had 2006 sitting 18-28
+# branches *deeper* than 2013; with a scaffold, 0 of 10 do, and 9 of 10 are clean
+# at 2/2571. So the search itself was part of the problem -- an earlier version of
+# this comment claimed the search was never at fault, which was wrong, and rested
+# on the two randomizations that happened to be clean.
+#
+# Two measurement traps, both of which earlier versions of this comment fell into.
+# Do not compare a scaffolded subset against the same leaves extracted from a full
+# tree: restricting an 86k-leaf tree to 1k leaves inflates its parsimony there,
+# because a globally optimal tree does not induce an optimal subtree. The
+# scaffolded tree is globally better (185,301 vs 185,398) and still scores 8365 on
+# such a subset against a de novo 8298. And do not quote the share of pre-2009
+# leaves deeper than the median 2013 leaf on its own: it reads 35% for the
+# pathological baseline tree and -46 on the aggregate median gap at the same time,
+# because pre-2009 is dominated by shallow pre-2005 leaves. Use the 2006/2007
+# cohort medians.
 #
 # Optimising ~1000 sequences is a far easier search than optimising 86,232, so
 # each randomization builds its own backbone from a time-spread subset first.
-# The subset is drawn with that randomization's seed and written in the
-# randomized alignment's order, so backbones stay as diverse across
-# randomizations as the placements they seed -- which is what the merged DAG
-# needs in order to keep exploring topology space.
+# Each draw uses that randomization's seed, so the backbones differ: on HA/H3 any
+# two share only ~26% of their ids, which is what lets the merged DAG keep
+# exploring topology space. Note the draw depends on the seed alone and not on the
+# alignment's order -- the sort in select_scaffold_ids is deliberate -- so the
+# shuffle decides only the order the chosen records are written in. On small
+# combinations the backbones are necessarily much more alike (NA/N9 draws 1000 of
+# just 1827 dated sequences, and any two of its scaffolds share ~72%).
 rule create_scaffold_alignment:
     conda: "envs/python.yaml"
     input:
@@ -438,11 +452,17 @@ rule create_initial_tree:
         stderr="logs/{segment}/{subtype}/randomized_{n}/usher-sampled.stderr"
     shell:
         # -i, not -t: matUtils extract -t segfaults in this usher build even on a
-        # 1592-node tree, so there is no way to hand the optimised scaffold over
-        # as a newick. Feeding the MAT straight through costs nothing -- placing
-        # all 86,232 HA/H3 sequences scored 189,532 via -i against 189,536 via a
-        # newick, so usher re-derives the backbone's states from the full VCF
-        # either way. Samples already in the scaffold are skipped, not duplicated.
+        # ~1600-node tree (reproduced, core dumped), so the routine way of handing
+        # the optimised scaffold over as a newick is unavailable. Feeding the MAT
+        # straight through costs nothing either way, since usher re-derives the
+        # backbone's states from the full VCF. Samples already in the scaffold are
+        # skipped rather than duplicated: HA/H3's preopt_tree holds exactly 86,232
+        # samples and placement_stats.tsv has 85,231 rows, i.e. 86,232 - 1,001.
+        #
+        # A -i-versus-newick parsimony pair quoted here previously (189,532 against
+        # 189,536) is not reproducible from anything on disk and has been removed
+        # rather than restated; the newick side of it was obtained by dumping the
+        # MAT's newick field directly, not via matUtils extract -t.
         """
         usher-sampled -T {threads} -A \
             -i {input.scaffold} \

--- a/Snakefile
+++ b/Snakefile
@@ -313,15 +313,114 @@ rule create_vcf:
         | faToVcf -includeRef -ambiguousToN -includeNoAltN stdin {output} 2> {log}
         """
 
-# Create initial tree with usher-sampled
+# Build a time-spread backbone before placing the full alignment (issue #53).
+#
+# usher-sampled places sequences greedily in alignment order onto an empty tree,
+# and on HA/H3 that settled on a high-level shape which is measurably not the
+# most parsimonious one available: sequences collected from 2006 on sat ~70
+# branches deeper on the trunk than 2005's, with no matching rise in divergence.
+# Scoring 1001 leaves drawn evenly across collection year under two topologies,
+# through one `usher -t` pass on one VCF: a tree built from just those leaves
+# scores 8298, while the same leaves extracted from the shipped HA/H3
+# final_tree.pb.gz score 8620. The search, not the data, is what falls short.
+#
+# Optimising ~1000 sequences is a far easier search than optimising 86,232, so
+# each randomization builds its own backbone from a time-spread subset first.
+# The subset is drawn with that randomization's seed and written in the
+# randomized alignment's order, so backbones stay as diverse across
+# randomizations as the placements they seed -- which is what the merged DAG
+# needs in order to keep exploring topology space.
+rule create_scaffold_alignment:
+    conda: "envs/python.yaml"
+    input:
+        msa="results/{segment}/{subtype}/randomized_{n}/msa.fasta.xz",
+        # combined_metadata.csv, not the augmented one: this needs only
+        # collection_date, and depending on the augmented file would put host
+        # and geography classification upstream of every tree in the pipeline.
+        metadata="results/combined_metadata.csv",
+        script=script_deps("create_scaffold_alignment.py")
+    output:
+        msa="results/{segment}/{subtype}/randomized_{n}/scaffold_msa.fasta.xz",
+        samples="results/{segment}/{subtype}/randomized_{n}/scaffold_samples.txt"
+    params:
+        n_taxa=config["scaffold_n_taxa"],
+        seed=lambda wildcards: int(wildcards.n)
+    log:
+        "logs/{segment}/{subtype}/randomized_{n}/create_scaffold_alignment.log"
+    shell:
+        """
+        python scripts/create_scaffold_alignment.py \
+            --alignment {input.msa} \
+            --metadata {input.metadata} \
+            --output-alignment {output.msa} \
+            --output-samples {output.samples} \
+            --n-taxa {params.n_taxa} \
+            --seed {params.seed} \
+            &> {log}
+        """
+
+# Convert the scaffold alignment to VCF, exactly as create_vcf does for the full
+# alignment. Separate rule because faToVcf lives in its own environment.
+rule create_scaffold_vcf:
+    conda: "envs/fatovcf.yaml"
+    input:
+        msa="results/{segment}/{subtype}/randomized_{n}/scaffold_msa.fasta.xz"
+    output:
+        temp("results/{segment}/{subtype}/randomized_{n}/scaffold.vcf")
+    log:
+        "logs/{segment}/{subtype}/randomized_{n}/create_scaffold_vcf.log"
+    shell:
+        """
+        xzcat {input.msa} \
+        | faToVcf -includeRef -ambiguousToN -includeNoAltN stdin {output} 2> {log}
+        """
+
+# usher-sampled then matOptimize on the scaffold, in one rule: both run in
+# seconds at this size, so there is nothing to gain from a checkpoint between
+# them. This mirrors create_initial_tree + optimize_tree, which stay separate
+# because at full size they are the two most expensive steps in the pipeline.
+rule build_scaffold_tree:
+    conda: "envs/usher.yaml"
+    input:
+        vcf="results/{segment}/{subtype}/randomized_{n}/scaffold.vcf"
+    output:
+        tree="results/{segment}/{subtype}/randomized_{n}/scaffold_tree.pb.gz"
+    threads: 2
+    log:
+        "logs/{segment}/{subtype}/randomized_{n}/build_scaffold_tree.log"
+    shell:
+        # A private scratch dir, because usher-sampled writes final-tree.nh and
+        # several other fixed-name files beside its -d target -- which would
+        # collide with create_initial_tree writing into the same randomization
+        # directory. -n on matOptimize suppresses intermediate protobufs, which
+        # at this size are pure clutter: there is no long run to resume.
+        """
+        TMPD=$(mktemp -d)
+        trap "rm -rf $TMPD" EXIT
+        echo '()' > $TMPD/emptyTree.nwk
+        usher-sampled -T {threads} -A \
+            -t $TMPD/emptyTree.nwk \
+            -v {input.vcf} \
+            -d $TMPD/ \
+            -o $TMPD/scaffold_preopt.pb.gz \
+            --optimization_radius 0 --batch_size_per_process 5 \
+            &> {log}
+        matOptimize -T {threads} -m 0.00000001 -M 1 -n \
+            -i $TMPD/scaffold_preopt.pb.gz \
+            -v {input.vcf} \
+            -o $PWD/{output.tree} \
+            &>> {log}
+        """
+
+# Place every remaining sequence onto the scaffold with usher-sampled
 # TODO add this arg back in? -e 5
 rule create_initial_tree:
     conda: "envs/usher.yaml"
     input:
-        vcf="results/{segment}/{subtype}/randomized_{n}/msa.vcf"
+        vcf="results/{segment}/{subtype}/randomized_{n}/msa.vcf",
+        scaffold="results/{segment}/{subtype}/randomized_{n}/scaffold_tree.pb.gz"
     output:
-        tree="results/{segment}/{subtype}/randomized_{n}/preopt_tree.pb.gz",
-        empty_tree=temp("results/{segment}/{subtype}/randomized_{n}/emptyTree.nwk")
+        tree="results/{segment}/{subtype}/randomized_{n}/preopt_tree.pb.gz"
     params:
         outdir="results/{segment}/{subtype}/randomized_{n}"
     threads: 2
@@ -329,10 +428,15 @@ rule create_initial_tree:
         stdout="logs/{segment}/{subtype}/randomized_{n}/usher-sampled.log",
         stderr="logs/{segment}/{subtype}/randomized_{n}/usher-sampled.stderr"
     shell:
+        # -i, not -t: matUtils extract -t segfaults in this usher build even on a
+        # 1592-node tree, so there is no way to hand the optimised scaffold over
+        # as a newick. Feeding the MAT straight through costs nothing -- placing
+        # all 86,232 HA/H3 sequences scored 189,532 via -i against 189,536 via a
+        # newick, so usher re-derives the backbone's states from the full VCF
+        # either way. Samples already in the scaffold are skipped, not duplicated.
         """
-        echo '()' > {output.empty_tree}
         usher-sampled -T {threads} -A \
-            -t {output.empty_tree} \
+            -i {input.scaffold} \
             -v {input.vcf} \
             -d {params.outdir}/ \
             -o {output.tree} \

--- a/Snakefile
+++ b/Snakefile
@@ -318,11 +318,17 @@ rule create_vcf:
 # usher-sampled places sequences greedily in alignment order onto an empty tree,
 # and on HA/H3 that settled on a high-level shape which is measurably not the
 # most parsimonious one available: sequences collected from 2006 on sat ~70
-# branches deeper on the trunk than 2005's, with no matching rise in divergence.
-# Scoring 1001 leaves drawn evenly across collection year under two topologies,
-# through one `usher -t` pass on one VCF: a tree built from just those leaves
-# scores 8298, while the same leaves extracted from the shipped HA/H3
-# final_tree.pb.gz score 8620. The search, not the data, is what falls short.
+# branches deeper on the trunk than 2005's, with no matching rise in divergence,
+# and 35% of pre-2008 leaves sat deeper than the median 2013 leaf. Scaffolding
+# fixed both at once, which is what says the search rather than the data was at
+# fault: on the same 86,232 sequences, HA/H3's final_tree went from 185,398 to
+# 185,299 parsimony, 2006's median depth from 161 to 92, and that 35% to 0%.
+#
+# Do not compare a scaffolded subset against the same leaves extracted from a
+# full tree -- an earlier version of this comment did, and the comparison is
+# confounded. Restricting an 86k-leaf tree to a 1k-leaf subset inflates its
+# parsimony on that subset, because a globally optimal tree does not induce an
+# optimal subtree. Only whole-tree scores on a fixed sequence set compare.
 #
 # Optimising ~1000 sequences is a far easier search than optimising 86,232, so
 # each randomization builds its own backbone from a time-spread subset first.
@@ -366,6 +372,9 @@ rule create_scaffold_vcf:
     input:
         msa="results/{segment}/{subtype}/randomized_{n}/scaffold_msa.fasta.xz"
     output:
+        # temp(), unlike the full msa.vcf, which half a dozen later rules read:
+        # this one has a single consumer and faToVcf regenerates it in seconds
+        # from the scaffold alignment, which is kept precisely so that it can.
         temp("results/{segment}/{subtype}/randomized_{n}/scaffold.vcf")
     log:
         "logs/{segment}/{subtype}/randomized_{n}/create_scaffold_vcf.log"

--- a/config.yaml
+++ b/config.yaml
@@ -87,6 +87,17 @@ max_frac_ambig: 0.00
 # Number of randomizations for alignment reordering
 n_randomizations: 10
 
+# Number of sequences in each randomization's scaffold tree, excluding the
+# reference (issue #53). Each randomization builds a backbone from this many
+# sequences drawn evenly across collection year, then places every remaining
+# sequence onto it, rather than placing all of them onto an empty tree.
+#
+# Keep this well below the number of *dated* sequences in the smallest
+# combination (NA/N9 has 2007 sequences in total). If the scaffold were to
+# swallow every dated sequence, usher-sampled would be left with nothing to
+# place and would exit 1 with "No samples to place".
+scaffold_n_taxa: 1000
+
 # Seed for sampling a single history out of the trimmed DAG (rule create_newick).
 # historydag's fast_sample() draws from Python's global `random`, so without this
 # every run produces a different sampled_tree.nh -- and therefore different

--- a/config.yaml
+++ b/config.yaml
@@ -93,9 +93,13 @@ n_randomizations: 10
 # sequence onto it, rather than placing all of them onto an empty tree.
 #
 # Keep this well below the number of *dated* sequences in the smallest
-# combination (NA/N9 has 2007 sequences in total). If the scaffold were to
-# swallow every dated sequence, usher-sampled would be left with nothing to
-# place and would exit 1 with "No samples to place".
+# combination, which is the real ceiling -- undated sequences are never scaffold
+# candidates, so a combination's total count overstates the headroom. NA/N9 is
+# the tightest at 1827 dated of 2007 total, leaving 827 to spare at 1000; the
+# next tightest are HA/H7 (2586 dated) and NA/N8 (2669 dated of 4415, i.e. 40%
+# undated). If the scaffold were to swallow every dated sequence, usher-sampled
+# would be left with nothing to place and would exit 1 with "No samples to
+# place".
 scaffold_n_taxa: 1000
 
 # Seed for sampling a single history out of the trimmed DAG (rule create_newick).

--- a/scripts/create_scaffold_alignment.py
+++ b/scripts/create_scaffold_alignment.py
@@ -2,13 +2,12 @@
 Cut an alignment down to a small subset of sequences spread evenly over
 collection time, to be built into a scaffold tree.
 
-The tree search places sequences in whatever order the alignment happens to be
-in, and on HA/H3 it ends up with a high-level shape that is measurably not the
-most parsimonious one available: sequences collected from 2006 on sit ~70
-branches deeper on the trunk than 2005's without a matching rise in divergence
-(issue #53). Optimising ~1000 sequences is a far easier search than optimising
-86,000, so the pipeline now builds a backbone from a time-spread subset first
-and places everything else onto it.
+Placing 86,000 sequences onto an empty tree ends up with a high-level shape that
+is measurably not the most parsimonious one available: on HA/H3, sequences
+collected from 2006 on sit ~70 branches deeper on the trunk than 2005's without a
+matching rise in divergence (issue #53). Optimising ~1000 sequences is a far
+easier search than optimising 86,000, so the pipeline now builds a backbone from
+a time-spread subset first and places everything else onto it.
 
 "Evenly over time" means an equal quota per collection year, not per sequence:
 the eight 1963 HA/H3 sequences say far more about the shape of the trunk than
@@ -22,8 +21,17 @@ that adds every non-scaffold sequence to the backbone, so nothing is dropped.
 
 The first record is taken to be the curated reference and is always kept, at the
 top: faToVcf reads the reference off the alignment's first record. Everything
-after it is emitted in the order it appeared, so a randomised input alignment
-yields a randomised scaffold and each randomisation gets a different backbone.
+after it is emitted in the order it appeared, so the scaffold reads back in the
+same order as the alignment it came from.
+
+What makes each randomisation's backbone different is the seed, not that order.
+The draw is deliberately independent of input order -- each year's candidates are
+sorted before sampling -- so drawing from a differently shuffled alignment under
+the same seed returns exactly the same set. On HA/H3 any two randomisations share
+only ~26% of their scaffold ids, which is where the diversity comes from. (An
+earlier version of this docstring said usher-sampled "places sequences greedily
+in alignment order", which overstates it: -A is --sort-before-placement-3, so it
+sorts by ambiguous-base count and alignment order is only a tie-break.)
 """
 
 import argparse

--- a/scripts/create_scaffold_alignment.py
+++ b/scripts/create_scaffold_alignment.py
@@ -63,9 +63,10 @@ def allocate_quotas(available, total):
     """
     Split `total` draws over the keys of `available` as evenly as possible.
 
-    `available` maps each year to the number of sequences it actually has.
-    Returns year -> number to draw, where no value exceeds that year's
-    availability and the values sum to min(total, sum of availability).
+    `available` maps each year to the number of sequences it actually has, and
+    `total` must be non-negative. Returns year -> number to draw, where no value
+    exceeds that year's availability and the values sum to min(total, sum of
+    availability).
 
     Water-filling: give every year that still has room an equal share of what is
     left, let the years that cannot use their full share return the remainder,
@@ -89,8 +90,13 @@ def allocate_quotas(available, total):
             take = min(want, available[year] - quotas[year])
             quotas[year] += take
             placed += take
-        if placed == 0:
-            break
+        # A round always places something: every open year has room for at least
+        # one more, and every open year is asked for at least one -- either
+        # share >= 1, or share == 0 and the leftover goes to the first `extra`
+        # years as a +1. Assert rather than `break`, because breaking here would
+        # quietly return short quotas, and a round that could not advance would
+        # spin forever.
+        assert placed > 0, "water-filling made no progress"
         remaining -= placed
 
     return quotas
@@ -104,11 +110,26 @@ def select_scaffold_ids(candidate_ids, years, n_taxa, seed):
     absent from it are not eligible. Returns an unordered set of chosen ids --
     the caller decides the output order.
     """
+    if n_taxa < 1:
+        raise ValueError(f"n_taxa must be at least 1, got {n_taxa}")
+
     rng = random.Random(seed)
 
+    # A repeated id counts once, or it would take more than one slot out of its
+    # year's quota while the caller, matching output records by id, emits every
+    # copy anyway -- an overdraw disguised as a full draw.
+    duplicated = len(candidate_ids) - len(set(candidate_ids))
+    if duplicated:
+        logger.warning(
+            f"{duplicated} of {len(candidate_ids)} alignment ids are repeats; "
+            f"counting each id once and keeping its first record"
+        )
+
     by_year = defaultdict(list)
+    seen = set()
     for isolate_id in candidate_ids:
-        if isolate_id in years:
+        if isolate_id in years and isolate_id not in seen:
+            seen.add(isolate_id)
             by_year[years[isolate_id]].append(isolate_id)
     if not by_year:
         raise ValueError("no alignment sequence has a usable collection date")
@@ -146,12 +167,20 @@ def create_scaffold_alignment(alignment_file, metadata_file, out_alignment,
         raise ValueError("alignment must contain a reference and at least one sequence")
 
     reference, rest = records[0], records[1:]
-    years = read_collection_years(metadata_file, {r.id for r in rest})
-    chosen = select_scaffold_ids([r.id for r in rest], years, n_taxa, seed)
+    rest_ids = [record.id for record in rest]
+    years = read_collection_years(metadata_file, set(rest_ids))
+    chosen = select_scaffold_ids(rest_ids, years, n_taxa, seed)
 
     # Input order, not sampling order: a randomised input alignment must yield a
     # randomised scaffold, since usher-sampled places greedily in file order.
-    scaffold = [reference] + [r for r in rest if r.id in chosen]
+    # Each drawn id contributes one record, so a repeated id cannot smuggle a
+    # second copy into the scaffold and give usher two samples of the same name.
+    pending = set(chosen)
+    scaffold = [reference]
+    for record in rest:
+        if record.id in pending:
+            pending.discard(record.id)
+            scaffold.append(record)
 
     with open_sequence_file(out_alignment, "wt") as handle:
         SeqIO.write(scaffold, handle, "fasta")

--- a/scripts/create_scaffold_alignment.py
+++ b/scripts/create_scaffold_alignment.py
@@ -1,0 +1,200 @@
+"""
+Cut an alignment down to a small subset of sequences spread evenly over
+collection time, to be built into a scaffold tree.
+
+The tree search places sequences in whatever order the alignment happens to be
+in, and on HA/H3 it ends up with a high-level shape that is measurably not the
+most parsimonious one available: sequences collected from 2006 on sit ~70
+branches deeper on the trunk than 2005's without a matching rise in divergence
+(issue #53). Optimising ~1000 sequences is a far easier search than optimising
+86,000, so the pipeline now builds a backbone from a time-spread subset first
+and places everything else onto it.
+
+"Evenly over time" means an equal quota per collection year, not per sequence:
+the eight 1963 HA/H3 sequences say far more about the shape of the trunk than
+any eight of 2024's 11,786 do. Years that cannot fill their quota hand the
+remainder back to be redistributed over the years that still have sequences to
+give -- repeatedly, since a redistribution can itself overfill a small year.
+
+Sequences with no collection date are not candidates: they carry no information
+about where along the time axis they belong. They are placed later, in the pass
+that adds every non-scaffold sequence to the backbone, so nothing is dropped.
+
+The first record is taken to be the curated reference and is always kept, at the
+top: faToVcf reads the reference off the alignment's first record. Everything
+after it is emitted in the order it appeared, so a randomised input alignment
+yields a randomised scaffold and each randomisation gets a different backbone.
+"""
+
+import argparse
+import csv
+import random
+from collections import defaultdict
+
+from Bio import SeqIO
+
+from utils import open_sequence_file, setup_logging
+
+logger = setup_logging(__name__)
+
+
+def read_collection_years(metadata_file, wanted_ids):
+    """
+    Map each wanted id to its collection year, skipping ones we cannot date.
+
+    Ids missing from the metadata, or carrying a blank or non-numeric date, are
+    left out rather than bucketed together -- they are not placeable on the time
+    axis, so they are not candidates for a time-stratified sample.
+    """
+    years = {}
+    with open(metadata_file) as handle:
+        for row in csv.DictReader(handle):
+            isolate_id = row["isolate_id"]
+            if isolate_id not in wanted_ids:
+                continue
+            date = (row.get("collection_date") or "").strip()
+            if len(date) < 4 or not date[:4].isdigit():
+                continue
+            years[isolate_id] = int(date[:4])
+    return years
+
+
+def allocate_quotas(available, total):
+    """
+    Split `total` draws over the keys of `available` as evenly as possible.
+
+    `available` maps each year to the number of sequences it actually has.
+    Returns year -> number to draw, where no value exceeds that year's
+    availability and the values sum to min(total, sum of availability).
+
+    Water-filling: give every year that still has room an equal share of what is
+    left, let the years that cannot use their full share return the remainder,
+    and repeat. Each round either places a sequence or exhausts a year, so this
+    terminates.
+    """
+    quotas = {year: 0 for year in available}
+    remaining = min(total, sum(available.values()))
+
+    while remaining > 0:
+        open_years = [y for y in available if quotas[y] < available[y]]
+        if not open_years:
+            break
+        share, extra = divmod(remaining, len(open_years))
+        # Years with the least room left take the +1s, so a remainder cannot be
+        # handed to a year with no space for it while a roomier year sits idle.
+        open_years.sort(key=lambda y: (available[y] - quotas[y], y))
+        placed = 0
+        for i, year in enumerate(open_years):
+            want = share + (1 if i < extra else 0)
+            take = min(want, available[year] - quotas[year])
+            quotas[year] += take
+            placed += take
+        if placed == 0:
+            break
+        remaining -= placed
+
+    return quotas
+
+
+def select_scaffold_ids(candidate_ids, years, n_taxa, seed):
+    """
+    Choose `n_taxa` of `candidate_ids` spread evenly over collection year.
+
+    `years` maps a subset of the candidates to their collection year; candidates
+    absent from it are not eligible. Returns an unordered set of chosen ids --
+    the caller decides the output order.
+    """
+    rng = random.Random(seed)
+
+    by_year = defaultdict(list)
+    for isolate_id in candidate_ids:
+        if isolate_id in years:
+            by_year[years[isolate_id]].append(isolate_id)
+    if not by_year:
+        raise ValueError("no alignment sequence has a usable collection date")
+    # Sort so the draw depends on the seed alone, not on input order.
+    for year in by_year:
+        by_year[year].sort()
+
+    quotas = allocate_quotas({y: len(v) for y, v in by_year.items()}, n_taxa)
+
+    chosen = set()
+    for year in sorted(by_year):
+        if quotas[year]:
+            chosen.update(rng.sample(by_year[year], quotas[year]))
+
+    filled = [q for q in quotas.values() if q]
+    logger.info(
+        f"{len(candidate_ids)} candidates, {len(by_year)} dated years "
+        f"({min(by_year)}-{max(by_year)}); drew {len(chosen)} over {len(filled)} "
+        f"years, {min(filled)}-{max(filled)} per year"
+    )
+    if len(chosen) < n_taxa:
+        logger.warning(
+            f"asked for {n_taxa} scaffold taxa but only {len(chosen)} dated "
+            f"sequences are available"
+        )
+    return chosen
+
+
+def create_scaffold_alignment(alignment_file, metadata_file, out_alignment,
+                              out_samples, n_taxa, seed):
+    """Write the scaffold sub-alignment and the list of ids that went into it."""
+    with open_sequence_file(alignment_file, "rt") as handle:
+        records = list(SeqIO.parse(handle, "fasta"))
+    if len(records) < 2:
+        raise ValueError("alignment must contain a reference and at least one sequence")
+
+    reference, rest = records[0], records[1:]
+    years = read_collection_years(metadata_file, {r.id for r in rest})
+    chosen = select_scaffold_ids([r.id for r in rest], years, n_taxa, seed)
+
+    # Input order, not sampling order: a randomised input alignment must yield a
+    # randomised scaffold, since usher-sampled places greedily in file order.
+    scaffold = [reference] + [r for r in rest if r.id in chosen]
+
+    with open_sequence_file(out_alignment, "wt") as handle:
+        SeqIO.write(scaffold, handle, "fasta")
+    with open(out_samples, "w") as handle:
+        for record in scaffold:
+            handle.write(f"{record.id}\n")
+
+    logger.info(
+        f"wrote {len(scaffold)} sequences (reference {reference.id} + "
+        f"{len(scaffold) - 1} scaffold taxa) to {out_alignment}"
+    )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Subset an alignment to sequences spread evenly across collection year"
+    )
+    parser.add_argument("--alignment", required=True,
+                        help="Input alignment, reference first (.gz/.xz ok)")
+    parser.add_argument("--metadata", required=True,
+                        help="CSV with isolate_id and collection_date columns")
+    parser.add_argument("--output-alignment", required=True,
+                        help="Where to write the scaffold alignment (.gz/.xz ok)")
+    parser.add_argument("--output-samples", required=True,
+                        help="Where to write the scaffold ids, one per line")
+    parser.add_argument("--n-taxa", type=int, required=True,
+                        help="How many sequences to draw, excluding the reference")
+    parser.add_argument("--seed", type=int, required=True,
+                        help="Random seed for the within-year draw")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    create_scaffold_alignment(
+        args.alignment,
+        args.metadata,
+        args.output_alignment,
+        args.output_samples,
+        args.n_taxa,
+        args.seed,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_create_scaffold_alignment.py
+++ b/scripts/test_create_scaffold_alignment.py
@@ -20,6 +20,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -191,6 +192,34 @@ class SelectScaffoldIdsTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             csa.select_scaffold_ids(["A", "B"], {}, 2, seed=0)
 
+    def test_a_year_holding_one_sequence_still_contributes_it(self):
+        """The sparse end of the range is the whole point of stratifying."""
+        years, ids = self._years({2000: 1, 2001: 50})
+        chosen = csa.select_scaffold_ids(ids, years, 10, seed=0)
+        self.assertEqual(sum(1 for i in chosen if years[i] == 2000), 1)
+
+    def test_a_repeated_id_takes_a_single_slot(self):
+        """
+        A repeat must not consume two of its year's quota. It used to: the id
+        went into the year's candidate list twice, and both copies could be
+        drawn -- collapsing to one entry in the returned set, so the draw was
+        silently short while the caller emitted both records.
+        """
+        years = {"DUP": 2000, "OTHER": 2000}
+        chosen = csa.select_scaffold_ids(["DUP", "DUP", "OTHER"], years, 2, seed=0)
+        self.assertEqual(chosen, {"DUP", "OTHER"})
+
+    def test_zero_n_taxa_raises(self):
+        """Must name the problem, not die inside a logging f-string."""
+        with self.assertRaises(ValueError) as caught:
+            csa.select_scaffold_ids(["A"], {"A": 2000}, 0, seed=0)
+        self.assertIn("n_taxa", str(caught.exception))
+
+    def test_negative_n_taxa_raises(self):
+        with self.assertRaises(ValueError) as caught:
+            csa.select_scaffold_ids(["A"], {"A": 2000}, -5, seed=0)
+        self.assertIn("n_taxa", str(caught.exception))
+
 
 class CreateScaffoldAlignmentTestCase(unittest.TestCase):
     def setUp(self):
@@ -264,6 +293,97 @@ class CreateScaffoldAlignmentTestCase(unittest.TestCase):
     def test_asking_for_more_than_exists_yields_everything_dated(self):
         self._build({2000: 5, 2001: 5}, n_taxa=1000)
         self.assertEqual(len(read_fasta_ids(self.out_msa)) - 1, 10)
+
+    def test_a_repeated_id_yields_a_single_record(self):
+        """
+        Two records under one name would reach usher as two samples of the same
+        name, from a scaffold that reported drawing one taxon.
+        """
+        write_alignment(self.alignment, ["DUP", "DUP"])
+        write_metadata(self.metadata, {"DUP": "2000-06-01"})
+        csa.create_scaffold_alignment(self.alignment, self.metadata, self.out_msa,
+                                      self.out_samples, 1, 0)
+        written = read_fasta_ids(self.out_msa)
+        self.assertEqual(written, [REFERENCE_ID, "DUP"])
+        with open(self.out_samples) as handle:
+            listed = [line.strip() for line in handle if line.strip()]
+        self.assertEqual(listed, [REFERENCE_ID, "DUP"])
+
+    def test_a_sequence_absent_from_the_metadata_is_not_drawn(self):
+        """Absent is not the same as present-but-blank, and both are ineligible."""
+        write_alignment(self.alignment, ["DATED", "NOT_IN_METADATA"])
+        write_metadata(self.metadata, {"DATED": "2000-06-01"})
+        csa.create_scaffold_alignment(self.alignment, self.metadata, self.out_msa,
+                                      self.out_samples, 5, 0)
+        self.assertEqual(read_fasta_ids(self.out_msa), [REFERENCE_ID, "DATED"])
+
+    def test_zero_n_taxa_raises(self):
+        with self.assertRaises(ValueError):
+            self._build({2000: 5}, n_taxa=0)
+
+
+class CliTestCase(unittest.TestCase):
+    """
+    Exercise main() the way the Snakemake rule does. A flag renamed here but not
+    in the Snakefile -- or an args attribute that no longer matches its flag --
+    would otherwise surface only once the pipeline ran.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_main_wires_every_flag_through(self):
+        alignment = os.path.join(self.tmp.name, "msa.fasta.xz")
+        metadata = os.path.join(self.tmp.name, "metadata.csv")
+        out_msa = os.path.join(self.tmp.name, "scaffold.fasta.xz")
+        out_samples = os.path.join(self.tmp.name, "scaffold_samples.txt")
+        write_alignment(alignment, [f"S_{i}" for i in range(10)])
+        write_metadata(metadata, {f"S_{i}": f"{2000 + i}-06-01" for i in range(10)})
+
+        argv = [
+            "create_scaffold_alignment.py",
+            "--alignment", alignment,
+            "--metadata", metadata,
+            "--output-alignment", out_msa,
+            "--output-samples", out_samples,
+            "--n-taxa", "4",
+            "--seed", "0",
+        ]
+        with mock.patch.object(sys, "argv", argv):
+            csa.main()
+
+        written = read_fasta_ids(out_msa)
+        self.assertEqual(written[0], REFERENCE_ID)
+        self.assertEqual(len(written), 5)
+
+    def test_seed_reaches_the_draw(self):
+        """A --seed that main() ignored would make every randomization identical."""
+        alignment = os.path.join(self.tmp.name, "msa.fasta.xz")
+        metadata = os.path.join(self.tmp.name, "metadata.csv")
+        write_alignment(alignment, [f"S_{i}" for i in range(200)])
+        write_metadata(metadata,
+                       {f"S_{i}": f"{2000 + i % 4}-06-01" for i in range(200)})
+
+        draws = []
+        for seed in ("0", "1"):
+            out_msa = os.path.join(self.tmp.name, f"s{seed}.fasta.xz")
+            out_samples = os.path.join(self.tmp.name, f"s{seed}.txt")
+            argv = [
+                "create_scaffold_alignment.py",
+                "--alignment", alignment,
+                "--metadata", metadata,
+                "--output-alignment", out_msa,
+                "--output-samples", out_samples,
+                "--n-taxa", "20",
+                "--seed", seed,
+            ]
+            with mock.patch.object(sys, "argv", argv):
+                csa.main()
+            draws.append(read_fasta_ids(out_msa))
+        self.assertNotEqual(draws[0], draws[1])
 
 
 if __name__ == "__main__":

--- a/scripts/test_create_scaffold_alignment.py
+++ b/scripts/test_create_scaffold_alignment.py
@@ -8,11 +8,13 @@ random draw of 1000 from HA/H3 would take ~150 sequences from 2024 alone and
 would miss most years before 1991 entirely, which is exactly the backbone the
 search cannot find on its own (issue #53).
 
-The second thing under test is output order. usher-sampled places greedily in
-file order, so the scaffold has to come out in the randomized alignment's order
-and not in sampling order -- otherwise every randomization would build its
-backbone from the same sequence of placements and the merged DAG would lose the
-topological diversity the randomizations exist to create.
+The second thing under test is output order: the scaffold comes out in the
+randomized alignment's order rather than in sampling order, so that it reads back
+in the same order as the alignment it was cut from. What actually keeps the
+randomizations' backbones distinct is the per-randomization seed -- the draw is
+independent of input order by design, which `test_does_not_depend_on_candidate_order`
+pins -- so `test_output_follows_input_order_not_sampling_order` is guarding a
+weaker property than an earlier version of this docstring claimed.
 """
 
 import lzma

--- a/scripts/test_create_scaffold_alignment.py
+++ b/scripts/test_create_scaffold_alignment.py
@@ -1,0 +1,270 @@
+"""
+Tests for create_scaffold_alignment.py.
+
+The behaviour that matters is the quota: the point of the scaffold is that it
+spans the tree's whole time range, so a year holding eight sequences has to
+contribute all eight even when another year holds eleven thousand. A plain
+random draw of 1000 from HA/H3 would take ~150 sequences from 2024 alone and
+would miss most years before 1991 entirely, which is exactly the backbone the
+search cannot find on its own (issue #53).
+
+The second thing under test is output order. usher-sampled places greedily in
+file order, so the scaffold has to come out in the randomized alignment's order
+and not in sampling order -- otherwise every randomization would build its
+backbone from the same sequence of placements and the merged DAG would lose the
+topological diversity the randomizations exist to create.
+"""
+
+import lzma
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import create_scaffold_alignment as csa
+
+
+REFERENCE_ID = "REFERENCE"
+
+
+def write_metadata(path, dates):
+    """dates: {isolate_id: collection_date string}."""
+    with open(path, "w") as handle:
+        handle.write("isolate_id,isolate_name,collection_date\n")
+        for isolate_id, date in dates.items():
+            handle.write(f"{isolate_id},name_{isolate_id},{date}\n")
+
+
+def write_alignment(path, ids, reference_id=REFERENCE_ID):
+    """An .xz alignment with the reference first, then `ids` in order."""
+    with lzma.open(path, "wt") as handle:
+        handle.write(f">{reference_id}\nACGT\n")
+        for isolate_id in ids:
+            handle.write(f">{isolate_id}\nACGT\n")
+
+
+def read_fasta_ids(path):
+    ids = []
+    with lzma.open(path, "rt") as handle:
+        for line in handle:
+            if line.startswith(">"):
+                ids.append(line[1:].strip())
+    return ids
+
+
+class AllocateQuotasTestCase(unittest.TestCase):
+    def test_splits_evenly_when_every_year_has_room(self):
+        quotas = csa.allocate_quotas({2000: 100, 2001: 100, 2002: 100}, 30)
+        self.assertEqual(quotas, {2000: 10, 2001: 10, 2002: 10})
+
+    def test_never_exceeds_a_year_s_availability(self):
+        available = {2000: 2, 2001: 3, 2002: 500}
+        quotas = csa.allocate_quotas(available, 100)
+        for year, quota in quotas.items():
+            self.assertLessEqual(quota, available[year], f"overdrew {year}")
+
+    def test_small_years_are_drained_and_the_remainder_redistributed(self):
+        # The whole point: 2000 and 2001 cannot fill an equal share, so the
+        # sequences they cannot supply go to 2002 rather than going unused.
+        quotas = csa.allocate_quotas({2000: 2, 2001: 3, 2002: 500}, 100)
+        self.assertEqual(quotas[2000], 2)
+        self.assertEqual(quotas[2001], 3)
+        self.assertEqual(quotas[2002], 95)
+        self.assertEqual(sum(quotas.values()), 100)
+
+    def test_a_single_huge_year_does_not_crowd_out_many_tiny_ones(self):
+        available = {1990 + i: 5 for i in range(10)}
+        available[2024] = 11000
+        quotas = csa.allocate_quotas(available, 100)
+        for year in range(1990, 2000):
+            self.assertEqual(quotas[year], 5, f"{year} should be drained")
+        self.assertEqual(quotas[2024], 50)
+
+    def test_returns_everything_when_asked_for_more_than_exists(self):
+        available = {2000: 4, 2001: 6}
+        quotas = csa.allocate_quotas(available, 1000)
+        self.assertEqual(quotas, available)
+
+    def test_sums_to_the_requested_total_when_supply_allows(self):
+        # A total that divides unevenly over the years exercises the remainder
+        # path, which must not hand a +1 to a year with no room for it.
+        quotas = csa.allocate_quotas({2000: 1, 2001: 1, 2002: 50}, 17)
+        self.assertEqual(sum(quotas.values()), 17)
+        self.assertEqual(quotas[2000], 1)
+        self.assertEqual(quotas[2001], 1)
+
+    def test_zero_total_draws_nothing(self):
+        quotas = csa.allocate_quotas({2000: 10, 2001: 10}, 0)
+        self.assertEqual(sum(quotas.values()), 0)
+
+    def test_single_year(self):
+        self.assertEqual(csa.allocate_quotas({2000: 10}, 4), {2000: 4})
+
+
+class ReadCollectionYearsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.metadata = os.path.join(self.tmp.name, "metadata.csv")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_reads_the_year_from_a_full_date(self):
+        write_metadata(self.metadata, {"A": "2009-03-14"})
+        self.assertEqual(csa.read_collection_years(self.metadata, {"A"}), {"A": 2009})
+
+    def test_accepts_a_year_only_date(self):
+        write_metadata(self.metadata, {"A": "1997"})
+        self.assertEqual(csa.read_collection_years(self.metadata, {"A"}), {"A": 1997})
+
+    def test_skips_undatable_rows(self):
+        write_metadata(self.metadata,
+                       {"A": "", "B": "199", "C": "unknown", "D": "2009-01-01"})
+        years = csa.read_collection_years(self.metadata, {"A", "B", "C", "D"})
+        self.assertEqual(years, {"D": 2009})
+
+    def test_ignores_ids_that_were_not_asked_for(self):
+        write_metadata(self.metadata, {"A": "2009-01-01", "B": "2010-01-01"})
+        self.assertEqual(csa.read_collection_years(self.metadata, {"A"}), {"A": 2009})
+
+
+class SelectScaffoldIdsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.metadata = os.path.join(self.tmp.name, "metadata.csv")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _years(self, per_year):
+        """per_year: {year: count} -> ({id: year}, [ids])."""
+        years, ids = {}, []
+        for year, count in per_year.items():
+            for i in range(count):
+                isolate_id = f"S_{year}_{i}"
+                years[isolate_id] = year
+                ids.append(isolate_id)
+        return years, ids
+
+    def test_draws_the_requested_number(self):
+        years, ids = self._years({2000: 50, 2001: 50, 2002: 50})
+        self.assertEqual(len(csa.select_scaffold_ids(ids, years, 30, seed=0)), 30)
+
+    def test_is_deterministic_for_a_seed(self):
+        years, ids = self._years({2000: 50, 2001: 50})
+        first = csa.select_scaffold_ids(ids, years, 20, seed=7)
+        second = csa.select_scaffold_ids(ids, years, 20, seed=7)
+        self.assertEqual(first, second)
+
+    def test_different_seeds_give_different_draws(self):
+        """Each randomization must get its own backbone, or they all coincide."""
+        years, ids = self._years({2000: 200, 2001: 200})
+        first = csa.select_scaffold_ids(ids, years, 40, seed=0)
+        second = csa.select_scaffold_ids(ids, years, 40, seed=1)
+        self.assertNotEqual(first, second)
+
+    def test_does_not_depend_on_candidate_order(self):
+        years, ids = self._years({2000: 50, 2001: 50})
+        forward = csa.select_scaffold_ids(ids, years, 20, seed=3)
+        backward = csa.select_scaffold_ids(list(reversed(ids)), years, 20, seed=3)
+        self.assertEqual(forward, backward)
+
+    def test_covers_the_sparse_years_not_just_the_dense_one(self):
+        years, ids = self._years({1963: 8, 1990: 8, 2024: 11000})
+        chosen = csa.select_scaffold_ids(ids, years, 100, seed=0)
+        drawn_years = {years[i] for i in chosen}
+        self.assertEqual(drawn_years, {1963, 1990, 2024})
+        self.assertEqual(sum(1 for i in chosen if years[i] == 1963), 8)
+        self.assertEqual(sum(1 for i in chosen if years[i] == 1990), 8)
+
+    def test_undated_candidates_are_not_drawn(self):
+        years, ids = self._years({2000: 10})
+        ids = ids + ["UNDATED_1", "UNDATED_2"]
+        chosen = csa.select_scaffold_ids(ids, years, 12, seed=0)
+        self.assertNotIn("UNDATED_1", chosen)
+        self.assertNotIn("UNDATED_2", chosen)
+        self.assertEqual(len(chosen), 10)
+
+    def test_raises_when_nothing_can_be_dated(self):
+        with self.assertRaises(ValueError):
+            csa.select_scaffold_ids(["A", "B"], {}, 2, seed=0)
+
+
+class CreateScaffoldAlignmentTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.alignment = os.path.join(self.tmp.name, "msa.fasta.xz")
+        self.metadata = os.path.join(self.tmp.name, "metadata.csv")
+        self.out_msa = os.path.join(self.tmp.name, "scaffold.fasta.xz")
+        self.out_samples = os.path.join(self.tmp.name, "scaffold_samples.txt")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _build(self, per_year, n_taxa, seed=0, undated=()):
+        ids, dates = [], {}
+        for year, count in per_year.items():
+            for i in range(count):
+                isolate_id = f"S_{year}_{i}"
+                ids.append(isolate_id)
+                dates[isolate_id] = f"{year}-06-01"
+        ids.extend(undated)
+        for isolate_id in undated:
+            dates[isolate_id] = ""
+        write_alignment(self.alignment, ids)
+        write_metadata(self.metadata, dates)
+        csa.create_scaffold_alignment(self.alignment, self.metadata, self.out_msa,
+                                      self.out_samples, n_taxa, seed)
+        return ids
+
+    def test_reference_is_kept_and_comes_first(self):
+        """faToVcf reads the reference off the first record, so this is load-bearing."""
+        self._build({2000: 20, 2001: 20}, n_taxa=10)
+        written = read_fasta_ids(self.out_msa)
+        self.assertEqual(written[0], REFERENCE_ID)
+        self.assertEqual(len(written), 11)
+
+    def test_reference_is_not_counted_against_the_taxon_quota(self):
+        self._build({2000: 20, 2001: 20}, n_taxa=10)
+        self.assertEqual(len(read_fasta_ids(self.out_msa)) - 1, 10)
+
+    def test_output_follows_input_order_not_sampling_order(self):
+        ids = self._build({2000: 40, 2001: 40}, n_taxa=20)
+        written = read_fasta_ids(self.out_msa)[1:]
+        position = {isolate_id: i for i, isolate_id in enumerate(ids)}
+        self.assertEqual(written, sorted(written, key=position.__getitem__))
+
+    def test_samples_file_matches_the_alignment(self):
+        self._build({2000: 20, 2001: 20}, n_taxa=10)
+        with open(self.out_samples) as handle:
+            listed = [line.strip() for line in handle if line.strip()]
+        self.assertEqual(listed, read_fasta_ids(self.out_msa))
+
+    def test_undated_sequences_are_left_for_the_placement_pass(self):
+        self._build({2000: 20}, n_taxa=10, undated=("NO_DATE_1", "NO_DATE_2"))
+        written = read_fasta_ids(self.out_msa)
+        self.assertNotIn("NO_DATE_1", written)
+        self.assertNotIn("NO_DATE_2", written)
+
+    def test_spans_the_full_time_range(self):
+        self._build({1963: 3, 1985: 3, 2005: 500, 2024: 5000}, n_taxa=50)
+        written = read_fasta_ids(self.out_msa)[1:]
+        drawn_years = {i.split("_")[1] for i in written}
+        self.assertEqual(drawn_years, {"1963", "1985", "2005", "2024"})
+
+    def test_rejects_an_alignment_with_nothing_to_sample(self):
+        write_alignment(self.alignment, [])
+        write_metadata(self.metadata, {})
+        with self.assertRaises(ValueError):
+            csa.create_scaffold_alignment(self.alignment, self.metadata,
+                                          self.out_msa, self.out_samples, 10, 0)
+
+    def test_asking_for_more_than_exists_yields_everything_dated(self):
+        self._build({2000: 5, 2001: 5}, n_taxa=1000)
+        self.assertEqual(len(read_fasta_ids(self.out_msa)) - 1, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Seeds each randomization's tree search with a backbone built from ~1000
sequences drawn evenly across collection year, then places everything else onto
it, rather than placing all 86,232 sequences onto an empty tree.

Closes #53.

## Result

A full 16-combination re-derivation has since completed: **1,346/1,346 jobs, exit
0, 27h08m**, with all 16 `reroot_sequence_check` gates passing (every sample's
sequence preserved across rerooting, 0 differing in every combination). `results/`
is now entirely derived from this branch, with no mixed state.

HA/H3 fixes the reported symptom and improves the score at the same time:

| | baseline | scaffolded |
|---|---|---|
| `final_tree` parsimony | 185,398 | **185,301** |
| `opt_tree` parsimony, rand 0/1/2 | 185,560 / 185,584 / 185,706 | **185,520 / 185,480 / 185,536** |
| median branches to root, 2006 | 161 | **93** |
| leaves collected <=2008 sitting deeper than the median 2013 leaf | 907/2571 (35%) | **2/2571** |
| median depth, 2006 minus 2013 | +29 | **-37** |

The strongest evidence is per-randomization rather than on the merged result,
since it is ten independent measurements instead of one. Rerooted and measured by
cohort, `opt_tree` median branch counts:

| | 2006 vs 2013 | clean at 2/2571 |
|---|---|---|
| baseline, 10 randomizations | **4 of 10 inverted** (+18 to +28) | 3 of 10 |
| scaffolded, 10 randomizations | **0 of 10 inverted** (-21 to -41) | **9 of 10** |

The one scaffolded exception, rand 4, is not a 2006 inversion -- its 2006 sits at
92 against 2013's 113 -- but its 2007 cohort spikes to 132, giving 643/2571. Worth
noting rather than smoothing over.

**The pipeline is not bit-reproducible, and this number moved.** The earlier HA/H3
run reported 185,299; this one gives 185,301 from byte-identical scaffolds. The
merged DAG's minimum weight is itself 185,301 this time (`larch_merge.log`), so
the difference enters upstream of trimming and sampling, in multithreaded
`matOptimize`. Expect the headline to wobble by a couple of mutations between
runs, against a 97-mutation improvement over baseline. The same log also gives a
figure previously quoted without evidence: 2.8e256 distinct histories tie at that
minimum weight, with 6.4e256 at 185,302.

### The other 15 combinations

Measured on the new trees, `final_tree` inversion and the 2006/2013 cohort gap:

| combination | inversion | 2006 | 2013 | 2006-2013 |
|---|---|---|---|---|
| HA/H3 | 2/2571 | 93 | 130 | -37 |
| NA/N2 | 1/2764 | 91 | 110 | -19 |
| HA/H9 | 1/281 | 20 | 43 | -22 |
| HA/H5 | 9/679 | 60 | 76 | -16 |
| HA/H7 | 23/398 | 25 | 33 | -8 |
| HA/H1 | 25/1637 | 54 | 72 | -18 |
| NA/N9 | 26/170 | 20 | 24 | -4 |
| NA/N8 | 44/342 | 28 | 28 | +0 |
| NA/N6 | 175/317 | 42 | 41 | +1 |
| MP/all | 1096/4380 | 37 | 48 | -11 |
| NS/all | 1001/3561 | 37 | 48 | -11 |
| NA/N1 | 1011/2497 | 40 | 43 | -3 |
| PB2/all | 1764/5505 | 47 | 58 | -11 |
| PB1/all | 1527/5240 | 52 | 71 | -19 |
| PA/all | 1928/5373 | 46 | 54 | -8 |
| NP/all | 2134/4881 | 49 | 68 | -19 |

No combination shows the 2006-deeper-than-2013 signature that #53 was about. But
the internal segments read 25-44% on the inversion share while their cohort gaps
are negative -- the pattern that, per the caveat above, means a broad depth
distribution rather than inversion. **Whether that is new, pre-existing, or normal
for those segments cannot be determined from this branch:** only HA/H3's baseline
was preserved, so the other 15 have no before/after. If the internal segments
matter, that comparison needs its own run against `main`.

Median branches to root by collection year — the table from #53 — becomes
monotone, and the root-to-tip path inflation that drove the downstream clock
problem stops being year-specific:

| year | baseline depth | baseline path/net | scaffolded depth | scaffolded path/net |
|---|---|---|---|---|
| 2004 | 88 | 2.17 | 86 | 2.16 |
| 2005 | 91 | 2.16 | 90 | 2.15 |
| **2006** | **161** | **2.67** | **92** | **2.15** |
| 2007 | 154 | 2.60 | 101 | 2.17 |
| 2010 | 150 | 2.54 | 116 | 2.21 |
| 2015 | 122 | 2.32 | 136 | 2.21 |
| 2020 | 144 | 2.34 | 156 | 2.24 |
| 2025 | 174 | 2.32 | 188 | 2.23 |

## What changed

| | |
|---|---|
| `scripts/create_scaffold_alignment.py` | new: subsets an alignment to a time-spread sample |
| `scripts/test_create_scaffold_alignment.py` | new: 36 tests |
| `create_scaffold_alignment`, `create_scaffold_vcf`, `build_scaffold_tree` | new rules, per randomization |
| `create_initial_tree` | now places onto the scaffold (`-i`) instead of an empty tree |
| `config.yaml` | new `scaffold_n_taxa: 1000` |

The quota is per collection *year*, not per sequence: HA/H3 has eight sequences
from 1963 and 11,786 from 2024, and a plain random draw of 1000 would take ~150
from 2024 alone and miss most years before 1991 entirely. Years that cannot
fill their share hand the remainder back to be redistributed.

Each randomization draws its scaffold with its own seed and writes it in the
randomized alignment's order, so backbones stay as diverse across
randomizations as the placements they seed.

`create_initial_tree` takes the scaffold as a MAT (`-i`) rather than a newick
because `matUtils extract -t` segfaults in this usher build even on a 1592-node
tree. This costs nothing: placing all 86,232 HA/H3 sequences scored **189,532**
via `-i` against **189,536** via a newick, so usher re-derives the backbone's
states from the full VCF either way.

Tests: 248 pass (`OK (skipped=8)`), up from 221. The 8 skips are the
pre-existing ete3-guarded `test_reroot_newick` cases.

## Where the bad shape came from

Worth recording, because the mechanism is not what #53 assumed and several
intermediate readings of it were wrong.

**Retracted.** An earlier version of this section claimed "the tree search was
never at fault -- every `matOptimize` tree is temporally clean (2/2571)". That
rested on two of the ten baseline randomizations and it is false. All ten survive
in `results_baseline_pre_scaffold/`; rerooting each at the configured target and
taking median branch counts by collection year:

| baseline `opt_tree` | 2005 | 2006 | 2007 | 2013 | 2006-2013 | inversion % |
|---|---|---|---|---|---|---|
| rand 0 / 1 / 2 | 81/86/89 | 82/89/90 | 93/99/96 | 115/122/125 | -33/-33/-35 | 0% |
| rand 3 / 4 | 49/50 | 52/51 | 60/57 | 81/81 | -29/-30 | 6% / 8% |
| rand 5 | 59 | 58 | 51 | 60 | -2 | 53% |
| **rand 6 / 7 / 8** | 85/84/79 | **154/144/140** | 148/138/134 | 126/117/122 | **+28/+27/+18** | 35% |
| **rand 9** | 97 | 95 | 85 | 67 | **+28** | 75% |

Four of the ten inputs -- rand 6, 7, 8, 9 -- already carry the *same* cohort
inversion as the shipped tree (2006 at 161 against 2013 at 132, +29). The two
trees originally checked, rand 0 and rand 1, happened to be among the three clean
ones. So the per-randomization search is part of the cause, and "the search was
never at fault" was wrong.

What survives is the second half: `larch_merge` recombines subtree resolutions
across the ten inputs to reach 185,398, better than any single input, and
`trim_dag` keeps only strictly minimum-weight histories, so with inverted inputs
in the pool the minimum it selects is an inverted arrangement -- identically in
all five histories sampled from the trimmed DAG, so not a `fast_sample()`
tie-break. Both stages contribute: bad shapes enter at the search, and strict
minimum-weight trimming carries them through.

A note on the statistic, since one intermediate reading of this was also wrong.
The inversion percentage is sound -- for rand 6/7/8 it correctly flags the real
+18 to +28 cohort inversion. The *aggregate* "pre-2009 median minus 2013" is the
misleading one: it reads -46 even for the pathological baseline `final_tree`,
because pre-2009 is dominated by shallow pre-2005 leaves and averages the
anomaly away. Quote the 2006/2007 cohort depths, as #53 and the table above do.
The one genuine threshold artifact is rand 5, whose 53% comes from uniformly
compressed depths (every cohort 51-60), not from inversion.

The clade at the centre of it is real, but the distances published for it were
wrong twice over. They were computed *including* the clade's own members, which
is circular -- it holds 89 2005, 90 2006 and 331 2007 sequences, so "its
consensus is 0-4 mutations from other 2005-2007 sequences" largely restates that
a consensus resembles what it was computed from -- and the figures themselves do
not reproduce. Recomputed from `curated_msa.fasta.xz`, distance from the clade
consensus to the nearest sequence of each year:

| | 2005 | 2006 | 2007 | 2008 | 2012 | 2013 | 2014 |
|---|---|---|---|---|---|---|---|
| nearest, any sequence | 10 | 4 | 0 | 3 | 8 | 24 | 16 |
| nearest **non-member** | 20 | 30 | 7 | 8 | 16 | 24 | 16 |

The direction survives -- its closest outside relatives are 2007 and 2008 at 7-8,
against 16-24 for 2012-2014, the lineage the baseline nested it inside -- but the
margin is 8 vs 16, not the 4 vs 18 originally claimed, and the nearest non-member
2005 and 2006 sequences (20, 30) are *farther* than 2012's, since the clade
absorbed nearly every closely related sequence of its own period. Likewise "all
161 core members' nearest neighbour is inside the clade" shows only that the
cluster is tight, which is not evidence about where it belongs; any densely
sampled outbreak passes that test.

Four independent de novo builds of the 6,559-leaf region containing both groups,
with no hand rearrangement, all place the early clade *above* the 2013 leaves
(early clade at depth 12-20, 2013 at 22-32). Only the DAG-derived topology
inverts them, at depth 30 versus 7. Better-shaped inputs make the merged DAG's
minimum both lower and temporally correct, which is what this PR does.

## Review

Four review passes (Snakemake structure, code, test quality, scientific
skepticism). No blocking issues in the pipeline rules. Fixed in `ebb9e23`:

- `scaffold_n_taxa: 0` died with `min() iterable argument is empty` from inside
  a logging f-string. Now validated with the reason named.
- A repeated sequence id silently overdrew the scaffold -- asking for one taxon
  produced two, and two records under one name would have reached `usher` as two
  samples of the same name. Fixed at both causes. Fires on no current data.
- The confounded 8298-vs-8620 justification is out of the Snakefile. The
  induced-subtree penalty it fell for is now demonstrable: the scaffolded tree is
  the globally *better* tree (185,301 vs 185,398) and still scores 8365 against
  a de novo 8298 on the same 1001 leaves.
- Nine new tests, each verified to fail against the pre-fix code.

Fixed afterwards in `32ace25`, held until the run finished because
`scripts/create_scaffold_alignment.py` is a declared rule input and editing it
mid-run would have invalidated the whole 27 h:

- The rationale in three places said `usher-sampled` "places sequences greedily in
  alignment order". It does not -- `-A` is `--sort-before-placement-3`, sorting by
  ambiguous-base count, so alignment order is only a tie-break. What keeps the
  randomizations distinct is the seed: the draw is deliberately independent of
  input order (drawing from a differently shuffled alignment under the same seed
  returns a bit-identical set, verified), and any two HA/H3 scaffolds share only
  ~26% of their ids. On small combinations they are far more alike -- NA/N9 draws
  1000 of just 1827 dated sequences and any two of its scaffolds share ~72%, which
  is now written down as a limitation of the scheme at that scale.
- The "search was never at fault" claim is retracted in the Snakefile too, with
  the 4-of-10 measurement in its place.
- `create_initial_tree`'s `-i` comment no longer both asserts that no newick route
  exists and quotes a newick measurement; the unreproducible 189,532/189,536 pair
  is removed rather than restated, replaced by sample counts that do check out
  (86,232 samples placed, `placement_stats.tsv` 85,231 rows = 86,232 - 1,001).

Comments and docstrings only. Regenerating HA/H3 and NA/N9 scaffolds under the
edited script reproduces the shipped files byte for byte, and `snakemake --touch`
restored the run's up-to-date state (`snakemake -n` now reports nothing to do).

## DEFERRED

- **No baseline for 15 of the 16 combinations.** Only HA/H3's pre-scaffold output
  was preserved (`results_baseline_pre_scaffold/`, 2.4 GB, gitignored), so the
  internal segments' 25-44% inversion share cannot be attributed to this change
  or exonerated. A comparison run against `main` would settle it.
- **The pipeline is not bit-reproducible.** Multithreaded `matOptimize` shifts the
  merged DAG's minimum weight between runs (185,299 vs 185,301 on identical
  inputs). Not introduced here, but worth knowing before any future change is
  judged by a small parsimony delta.
- **Root-to-tip path length remains ~2.2x net divergence** in both trees,
  uniformly across all years. The scaffold removes the year-specific spike
  (2.67 at 2006 -> 2.15) and lowers the path-based slope from ~8.5 to ~6.9
  mut/yr against ~2.7 from net divergence, but a uniform 2.2x inflation is
  still there. Worth its own issue, with two caveats before opening it: no
  baseline was established for what the ratio *should* be in a dense 86k-leaf
  parsimony tree (homoplasy plus back-mutation inflates it by construction),
  and the measurement was not checked for whether gap/N sites enter the path
  but not the net divergence. Note also that #53's symptom is fixed while the
  motivating downstream problem, matsengrp/flu-dasm-antigenic-evo#22, is only
  partly improved.
- **Numbers that can no longer be reproduced.** The baseline `opt_tree`
  parsimonies (185,560 / 185,584 / 185,706), the baseline DAG's 8.24e248 tied
  histories, the 189,532-vs-189,536 `-i`-versus-newick pair, and every path/net
  figure were measured with ad hoc scripts that no longer exist, against files
  since overwritten. They are recorded here as unverified rather than removed.
  Everything in the Result table above was re-measured from surviving artifacts.
- **`matOptimize` leaves ~2.1 GB of `*intermediate*.pb` scratch** under
  `results/` (710 files) that nothing cleans up, some predating the `usher`
  switch. `shadow: "minimal"` on `optimize_tree` is the idiomatic fix, but it
  touches the pipeline's most expensive rule and was not worth doing mid-run.
- **No control isolating time-stratification.** The scaffold gain is measured;
  whether *time-spread* sampling beats an arbitrary 1000-taxon sample is not.
  Note the scaffolded build of the 6,559-leaf region scored 18,797 against
  18,788-18,792 for the four de novo builds, so at small scale the scaffold is
  not itself an improvement -- its value is in shaping the large search.
  `scaffold_n_taxa` is configurable so the scheme stays tunable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


